### PR TITLE
feat: Add pack command for generating .nupkg packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,8 @@ indent_size = 4
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = true
 csharp_new_line_before_open_brace = all
-csharp_preserve_single_line_blocks = false
+# Preserve single-line properties: { get; init; } instead of multi-line
+csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false
 # Prefer implicit types (var)
 csharp_style_var_for_built_in_types = true:suggestion

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Auto detect text files and normalize to LF on commit
+* text=auto eol=lf
+
+# Ensure these are always treated as text with LF line endings
+*.cs text eol=lf
+*.csproj text eol=lf
+*.props text eol=lf
+*.targets text eol=lf
+*.sln text eol=lf
+*.json text eol=lf
+*.xml text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.nuspec text eol=lf
+*.scriban text eol=lf
+*.editorconfig text eol=lf
+
+# Ensure batch and shell scripts have correct line endings
+*.sh text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files - don't modify
+*.dll binary
+*.exe binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.nupkg binary

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -202,6 +202,7 @@ When making changes to the codebase, **always update the relevant documentation 
 - Tests invoke the CLI via `dotnet run --project ConcordIO.Tool.csproj -- <command>` to test the real user experience.
 - Example pattern: Generate package → Pack as NuGet → Reference in test project → Build test project → Verify MSBuild items.
 - Collection-based fixtures: `[Collection(IntegrationTestCollection.Name)]` for shared fixture lifetime.
+- If multi-targeting (`<TargetFrameworks>`) causes MSBuild/NSwag orchestration failures in E2E tests, **prefer single-target test projects** (`<TargetFramework>`) and split coverage into separate per-framework tests (net8.0, net9.0, net10.0) instead of debugging brittle multi-TFM test wiring.
 
 ### Snapshot Testing with Verify
 - Snapshot tests use `await Verify(output)` to compare against approved snapshots.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ To check if code is properly formatted:
 dotnet format src/ConcordIO.Tool.sln --verify-no-changes
 ```
 
+### Testing
+
+E2E tests generate temporary consumer projects that now multi-target **net8.0;net9.0;net10.0** for CLI OpenAPI flows and **net9.0;net10.0** for AsyncAPI flows to validate tool packages across supported frameworks. This ensures MSBuild tasks and generated outputs work under all supported runtimes during end-to-end flows.
+
 ## License
 
 Licensed under the Apache License 2.0. See [LICENSE](LICENSE).

--- a/src/ConcordIO.AsyncApi.Client/ARCHITECTURE.md
+++ b/src/ConcordIO.AsyncApi.Client/ARCHITECTURE.md
@@ -20,6 +20,9 @@ ConcordIO.AsyncApi.Client is a NuGet tool package that runs at build time in con
 │  ConcordIOGenerateContracts (BeforeTargets=CoreCompile) │
 │     │  (DependsOnTargets=ResolveAssemblyReferences)     │
 │     │                                                   │
+│     ├─ RemoveDuplicates on @(ConcordIOAsyncApiContract)  │
+│     │  to avoid duplicate file processing                │
+│     │                                                   │
 │     ├─ Collect @(ReferencePath) for external types       │
 │     │                                                   │
 │     ├─ GenerateContractsTask.Execute()                  │
@@ -28,9 +31,10 @@ ConcordIO.AsyncApi.Client is a NuGet tool package that runs at build time in con
 │     │  │  ├─ LoadAsyncApiDocument() (YAML/JSON)         │
 │     │  │  ├─ AsyncApiContractGenerator.Generate()       │
 │     │  │  └─ Write .g.cs files                          │
-│     │  └─ Output: GeneratedFiles[]                      │
+│     │  └─ Output: distinct GeneratedFiles[]             │
 │     │                                                   │
-│     └─ Add @(_ConcordIOClientGeneratedFiles) to         │
+│     └─ RemoveDuplicates on generated paths, then add     │
+│        @(_ConcordIOClientGeneratedFilesDistinct) to      │
 │        <Compile> and <FileWrites>                       │
 │     ▼                                                   │
 │  CoreCompile (includes generated .g.cs files)           │
@@ -39,12 +43,18 @@ ConcordIO.AsyncApi.Client is a NuGet tool package that runs at build time in con
 
 ## Target Framework Strategy
 
-ConcordIO.AsyncApi.Client is multi-targeted to **.NET 9.0 and 10.0** to match the AsyncAPI dependency baseline.
+ConcordIO.AsyncApi.Client is multi-targeted to **.NET 8.0, 9.0, and 10.0** to support consuming projects across these versions.
 
 **Impact on Consumers**:
 
-- **Consuming projects targeting net9.0+** can use the MSBuild task at build time regardless of their TFM, because the task assembly is selected by the **MSBuild runtime**.
+- **Consuming projects targeting net8.0+** can use the MSBuild task at build time regardless of their TFM, because the task assembly is selected by the **MSBuild runtime**.
 - **The `.targets` file selects the task TFM from the MSBuild runtime version**, not from `$(TargetFramework)`, to avoid MetadataLoadContext-only loading when MSBuild runs on a different runtime than the project being built.
+
+**Task Selection Logic**:
+
+- .NET 8 MSBuild → loads `tools/net8.0/ConcordIO.AsyncApi.Client.dll`
+- .NET 9 MSBuild → loads `tools/net9.0/ConcordIO.AsyncApi.Client.dll`
+- .NET 10+ MSBuild → loads `tools/net10.0/ConcordIO.AsyncApi.Client.dll`
 
 ## Package Structure
 
@@ -56,12 +66,13 @@ ConcordIO.AsyncApi.Client.nupkg
 ├── buildTransitive/
 │   └── ConcordIO.AsyncApi.Client.props    # Imports build/props for transitive consumers
 └── tools/
+    ├── net8.0/
     ├── net9.0/
     └── net10.0/
         ├── ConcordIO.AsyncApi.Client.dll  # MSBuild task assembly
         ├── ConcordIO.AsyncApi.dll         # Core library (PrivateAssets=all)
         └── (NJsonSchema, Neuroglia, etc.) # Dependencies bundled as tools
-```text
+```
 
 ## Key Components
 
@@ -136,6 +147,7 @@ AsyncApiContractGenerator.Generate()  [in ConcordIO.AsyncApi]
 - Resolves the task assembly from the package `tools/$(_ConcordIOClientTaskTfm)` folder, where the task TFM is selected based on the MSBuild runtime version
 - Uses explicit task runtime/architecture hints (`CurrentRuntime` / `CurrentArchitecture`) to avoid MSBuild fallback task hosting
 - `ConcordIOGenerateContracts` — depends on `ResolveAssemblyReferences` to ensure `@(ReferencePath)` is populated, runs before `CoreCompile`, generates code, adds to `<Compile>`
+- The target deduplicates `@(ConcordIOAsyncApiContract)` inputs and generated file outputs using `RemoveDuplicates` to prevent duplicate compile includes and duplicate task processing when upstream targets re-emit items.
 - `ConcordIOCleanGeneratedContracts` — cleans generated directory after `Clean`
 
 **Transitive** (`buildTransitive/ConcordIO.AsyncApi.Client.props`):

--- a/src/ConcordIO.AsyncApi.Client/ARCHITECTURE.md
+++ b/src/ConcordIO.AsyncApi.Client/ARCHITECTURE.md
@@ -39,13 +39,12 @@ ConcordIO.AsyncApi.Client is a NuGet tool package that runs at build time in con
 
 ## Target Framework Strategy
 
-ConcordIO.AsyncApi.Client is multi-targeted to **.NET 9.0 and 10.0** only, due to NuGet dependency constraints (Neuroglia.AsyncApi.Core requires net9.0+).
+ConcordIO.AsyncApi.Client is multi-targeted to **.NET 9.0 and 10.0** to match the AsyncAPI dependency baseline.
 
 **Impact on Consumers**:
 
-- **Consuming projects targeting net6.0, net7.0, or net8.0** can still use AsyncAPI contracts via the generated contract packages
-- **But cannot use the MSBuild task at build time** if their project targets net6.0–8.0
-- The `.targets` file dynamically resolves `$(TargetFramework)` to select the appropriate framework-specific task assembly
+- **Consuming projects targeting net9.0+** can use the MSBuild task at build time regardless of their TFM, because the task assembly is selected by the **MSBuild runtime**.
+- **The `.targets` file selects the task TFM from the MSBuild runtime version**, not from `$(TargetFramework)`, to avoid MetadataLoadContext-only loading when MSBuild runs on a different runtime than the project being built.
 
 ## Package Structure
 
@@ -53,7 +52,7 @@ ConcordIO.AsyncApi.Client is multi-targeted to **.NET 9.0 and 10.0** only, due t
 ConcordIO.AsyncApi.Client.nupkg
 ├── build/
 │   ├── ConcordIO.AsyncApi.Client.props    # Default MSBuild properties
-│   └── ConcordIO.AsyncApi.Client.targets  # Task registration (uses dynamic $(TargetFramework) resolution)
+│   └── ConcordIO.AsyncApi.Client.targets  # Task registration (selects task by MSBuild runtime)
 ├── buildTransitive/
 │   └── ConcordIO.AsyncApi.Client.props    # Imports build/props for transitive consumers
 └── tools/
@@ -134,7 +133,8 @@ AsyncApiContractGenerator.Generate()  [in ConcordIO.AsyncApi]
 **Targets** (`build/ConcordIO.AsyncApi.Client.targets`):
 
 - Registers `GenerateContractsTask` via `<UsingTask>`
-- Resolves the task assembly from the package `tools/$(TargetFramework)` folder using `$(MSBuildThisFileDirectory)..\tools\$(TargetFramework)\`
+- Resolves the task assembly from the package `tools/$(_ConcordIOClientTaskTfm)` folder, where the task TFM is selected based on the MSBuild runtime version
+- Uses explicit task runtime/architecture hints (`CurrentRuntime` / `CurrentArchitecture`) to avoid MSBuild fallback task hosting
 - `ConcordIOGenerateContracts` — depends on `ResolveAssemblyReferences` to ensure `@(ReferencePath)` is populated, runs before `CoreCompile`, generates code, adds to `<Compile>`
 - `ConcordIOCleanGeneratedContracts` — cleans generated directory after `Clean`
 

--- a/src/ConcordIO.AsyncApi.Client/ConcordIO.AsyncApi.Client.csproj
+++ b/src/ConcordIO.AsyncApi.Client/ConcordIO.AsyncApi.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ConcordIO.AsyncApi.Client</RootNamespace>

--- a/src/ConcordIO.AsyncApi.Client/README.md
+++ b/src/ConcordIO.AsyncApi.Client/README.md
@@ -17,13 +17,17 @@ Add the package reference to your consumer project:
 
 When combined with a contract package that defines `ConcordIOAsyncApiContract` items, C# types are generated automatically before compilation.
 
+## Runtime Compatibility
+
+The MSBuild task assembly is packaged for **net9.0** and **net10.0**, and the `.targets` file selects the task based on the **MSBuild runtime**, not the consuming project's TFM.
+
 ## How It Works
 
 1. A **contract package** (produced by `ConcordIO.AsyncApi.Server` or `concordio generate`) exposes AsyncAPI spec files as `ConcordIOAsyncApiContract` MSBuild items.
 2. This **client package** picks up those items and runs `GenerateContractsTask` before `CoreCompile`.
 3. The task generates C# source files in `obj/{Config}/{TFM}/ConcordIO.AsyncApi.Generated/` and adds them to compilation.
 
-```
+```text
 Contract NuGet Package
   └── asyncapi/MyService.Contracts.yaml
   └── build/MyService.Contracts.targets  ←  defines <ConcordIOAsyncApiContract>
@@ -93,6 +97,7 @@ public partial class OrderCreatedEvent
 ## External Type Detection
 
 If a type defined in the AsyncAPI spec already exists in a referenced assembly, the generator will:
+
 1. **Skip** generating that type
 2. **Add** a `using` statement for its namespace
 
@@ -106,6 +111,29 @@ This avoids duplicate type definitions when contract types are shared via a comm
 | `ConcordIOCleanGeneratedContracts` | `AfterTargets="Clean"` | Removes the generated output directory. |
 
 ## Troubleshooting
+
+### Task instantiation error (MetadataLoadContext disposed)
+
+**Symptom**:
+
+```text
+The "ConcordIO.AsyncApi.Client.Tasks.GenerateContractsTask" task could not be instantiated...
+Type must be a type provided by the runtime.
+The "GenerateContractsTask" task generated invalid items...
+MetadataLoadContext that created it has been disposed.
+```
+
+**Cause**: The task assembly was selected based on `$(TargetFramework)` rather than the **MSBuild runtime**, causing MSBuild to load the task in a metadata-only context.
+
+**Solution**: Upgrade to a version that selects the task assembly by MSBuild runtime and includes a net9.0+ task build.
+
+### MSBuild warning about task runtime/architecture
+
+**Symptom**: Build shows a warning about the task falling back to out-of-process execution, sometimes followed by an MSBuild unhandled exception.
+
+**Cause**: Older package versions did not specify explicit task runtime/architecture hints.
+
+**Solution**: Upgrade to a version that includes explicit runtime/architecture hints in the MSBuild task registration.
 
 ### Generation doesn't run
 

--- a/src/ConcordIO.AsyncApi.Client/README.md
+++ b/src/ConcordIO.AsyncApi.Client/README.md
@@ -19,7 +19,10 @@ When combined with a contract package that defines `ConcordIOAsyncApiContract` i
 
 ## Runtime Compatibility
 
-The MSBuild task assembly is packaged for **net9.0** and **net10.0**, and the `.targets` file selects the task based on the **MSBuild runtime**, not the consuming project's TFM.
+The MSBuild task assembly is packaged for **net8.0**, **net9.0**, and **net10.0**, and the `.targets` file selects the task based on the **MSBuild runtime**, not the consuming project's TFM.
+
+- **Consuming projects targeting .NET 8 and above** can use this package regardless of their specific framework version.
+- Supports all modern .NET SDK builds (.NET 8/9/10).
 
 ## How It Works
 
@@ -52,7 +55,7 @@ All properties are optional with sensible defaults.
 
 | MSBuild Property | Default | Description |
 |-----------------|---------|-------------|
-| `ConcordIOClientOutputPath` | `$(IntermediateOutputPath)ConcordIO.AsyncApi.Generated\` | Output directory for generated files. |
+| `ConcordIOClientOutputPath` | `$(BaseIntermediateOutputPath)ConcordIO.AsyncApi.Generated\` | Output directory for generated files. |
 | `ConcordIOClientGenerateDataAnnotations` | `true` | Generate `[Required]`, `[StringLength]`, etc. |
 | `ConcordIOClientGenerateNullableReferenceTypes` | `true` | Generate nullable reference type annotations (`?`). |
 | `ConcordIOClientClassStyle` | `Poco` | Class style: `Poco` or `Record`. |
@@ -135,6 +138,18 @@ MetadataLoadContext that created it has been disposed.
 
 **Solution**: Upgrade to a version that includes explicit runtime/architecture hints in the MSBuild task registration.
 
+### MSBuild error parsing MSBuildRuntimeVersion
+
+**Symptom**:
+
+```text
+error MSB4184: The expression "[System.Version]::Parse('')" cannot be evaluated.
+```
+
+**Cause**: Some MSBuild hosts provide an empty `$(MSBuildRuntimeVersion)` during restore/build, which caused the task TFM selection logic to attempt parsing an empty version string.
+
+**Solution**: Upgrade to a version that guards empty `$(MSBuildRuntimeVersion)` values and falls back to the net9.0 task build.
+
 ### Generation doesn't run
 
 **Symptom**: Build succeeds but no `.g.cs` files are generated.
@@ -162,6 +177,26 @@ MetadataLoadContext that created it has been disposed.
 2. **Namespace conflicts**: Ensure `x-dotnet-namespace` values don't conflict with existing types
 
 3. **Missing dependencies**: Check that shared types are properly referenced
+
+### "Generating contracts from 2 AsyncAPI file(s)" with only one file on disk
+
+**Symptom**: Build logs show duplicate AsyncAPI processing and repeated `Generated ... from <file>` lines.
+
+**Cause**: Upstream package targets can re-emit `ConcordIOAsyncApiContract` items with `Include`, which duplicates the same file path in the MSBuild item list.
+
+**Current behavior**:
+
+1. Client template metadata enrichment updates items in-place (`Update`) instead of adding duplicates.
+2. The `ConcordIO.AsyncApi.Client` target removes duplicate AsyncAPI items before invoking the task.
+3. The task also deduplicates file paths as a defensive fallback.
+
+### Missing enum types from schema `definitions`
+
+**Symptom**: Generated classes reference enum types (for example `DhlRateSyncCancellationReason`) that are not emitted.
+
+**Cause**: Some contracts define enums only inside a parent schema's `definitions` block instead of as top-level `components/schemas` entries.
+
+**Current behavior**: The generator extracts definition-scoped enum schemas and emits them as regular generated types in the same namespace, while still avoiding duplicate generation of shared object definitions.
 
 ### External types not detected
 

--- a/src/ConcordIO.AsyncApi.Client/Tasks/GenerateContractsTask.cs
+++ b/src/ConcordIO.AsyncApi.Client/Tasks/GenerateContractsTask.cs
@@ -56,6 +56,31 @@ public class GenerateContractsTask : MSBuildTask
 	[Output]
 	public ITaskItem[] GeneratedFiles { get; set; } = [];
 
+	/// <summary>
+	/// Executes the contract generation task for the provided AsyncAPI files.
+	/// </summary>
+	/// <returns>
+	/// <c>true</c> when generation completes without errors; otherwise, <c>false</c>.
+	/// </returns>
+	/// <remarks>
+	/// <para>
+	/// The task parses each AsyncAPI document, generates C# source files into
+	/// <see cref="OutputDirectory"/>, and returns those paths via <see cref="GeneratedFiles"/>.
+	/// </para>
+	/// <para>
+	/// If any input file is missing or an exception occurs during generation,
+	/// the task logs the error and returns <c>false</c>.
+	/// </para>
+	/// </remarks>
+	/// <example>
+	/// <para>MSBuild usage:</para>
+	/// <code>
+	/// &lt;GenerateContractsTask
+	///     AsyncApiFiles="@(ConcordIOAsyncApiContract)"
+	///     OutputDirectory="$(IntermediateOutputPath)ConcordIO.AsyncApi.Generated\"
+	///     ReferencedAssemblies="@(ReferencePath)" /&gt;
+	/// </code>
+	/// </example>
 	public override bool Execute()
 	{
 		try

--- a/src/ConcordIO.AsyncApi.Client/Tasks/GenerateContractsTask.cs
+++ b/src/ConcordIO.AsyncApi.Client/Tasks/GenerateContractsTask.cs
@@ -77,7 +77,7 @@ public class GenerateContractsTask : MSBuildTask
 	/// <code>
 	/// &lt;GenerateContractsTask
 	///     AsyncApiFiles="@(ConcordIOAsyncApiContract)"
-	///     OutputDirectory="$(IntermediateOutputPath)ConcordIO.AsyncApi.Generated\"
+	///     OutputDirectory="$(BaseIntermediateOutputPath)ConcordIO.AsyncApi.Generated\"
 	///     ReferencedAssemblies="@(ReferencePath)" /&gt;
 	/// </code>
 	/// </example>
@@ -85,13 +85,19 @@ public class GenerateContractsTask : MSBuildTask
 	{
 		try
 		{
-			if (AsyncApiFiles.Length == 0)
+			var distinctAsyncApiFiles = AsyncApiFiles
+				.Select(item => item.ItemSpec)
+				.Where(path => !string.IsNullOrWhiteSpace(path))
+				.Distinct(StringComparer.OrdinalIgnoreCase)
+				.ToArray();
+
+			if (distinctAsyncApiFiles.Length == 0)
 			{
 				Log.LogMessage(MessageImportance.Normal, "ConcordIO.Client: No AsyncAPI files specified, skipping generation.");
 				return true;
 			}
 
-			Log.LogMessage(MessageImportance.High, "ConcordIO.Client: Generating contracts from {0} AsyncAPI file(s)...", AsyncApiFiles.Length);
+			Log.LogMessage(MessageImportance.High, "ConcordIO.Client: Generating contracts from {0} AsyncAPI file(s)...", distinctAsyncApiFiles.Length);
 
 			// Ensure output directory exists
 			Directory.CreateDirectory(OutputDirectory);
@@ -112,11 +118,10 @@ public class GenerateContractsTask : MSBuildTask
 
 			var generator = new AsyncApiContractGenerator(settings, resolver);
 			var generatedFiles = new List<ITaskItem>();
+			var generatedFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-			foreach (var asyncApiFile in AsyncApiFiles)
+			foreach (var filePath in distinctAsyncApiFiles)
 			{
-				var filePath = asyncApiFile.ItemSpec;
-
 				if (!File.Exists(filePath))
 				{
 					Log.LogWarning("ConcordIO.Client: AsyncAPI file not found: {0}", filePath);
@@ -139,7 +144,10 @@ public class GenerateContractsTask : MSBuildTask
 						var outputPath = Path.Combine(OutputDirectory, sourceFile.FileName);
 						File.WriteAllText(outputPath, sourceFile.Content);
 
-						generatedFiles.Add(new TaskItem(outputPath));
+						if (generatedFilePaths.Add(outputPath))
+						{
+							generatedFiles.Add(new TaskItem(outputPath));
+						}
 						Log.LogMessage(MessageImportance.Normal, "ConcordIO.Client: Generated {0} ({1} types)",
 							sourceFile.FileName, sourceFile.Types.Count);
 					}

--- a/src/ConcordIO.AsyncApi.Client/build/ConcordIO.AsyncApi.Client.targets
+++ b/src/ConcordIO.AsyncApi.Client/build/ConcordIO.AsyncApi.Client.targets
@@ -48,17 +48,26 @@
 
   <!--
     Internal: Locate the task assembly in the package tools folder
-    - _ConcordIOClientToolsDir (string): Absolute tools folder path for the current TargetFramework
+    - _ConcordIOClientTaskTfm (string): Task TFM based on the MSBuild runtime (net8.0 fallback)
+    - _ConcordIOClientToolsDir (string): Absolute tools folder path for the task TFM
     - _ConcordIOClientTaskAssembly (string): Full path to ConcordIO.AsyncApi.Client.dll for UsingTask
+    - _ConcordIOClientTaskRuntime (string): MSBuild task runtime hint (CurrentRuntime by default)
+    - _ConcordIOClientTaskArchitecture (string): MSBuild task architecture hint (CurrentArchitecture by default)
   -->
   <PropertyGroup>
-    <_ConcordIOClientToolsDir>$(MSBuildThisFileDirectory)..\tools\$(TargetFramework)\</_ConcordIOClientToolsDir>
+    <_ConcordIOClientTaskTfm>net9.0</_ConcordIOClientTaskTfm>
+    <_ConcordIOClientTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' and $([System.Version]::Parse('$(MSBuildRuntimeVersion)').Major) &gt;= 10">net10.0</_ConcordIOClientTaskTfm>
+    <_ConcordIOClientToolsDir>$(MSBuildThisFileDirectory)..\tools\$(_ConcordIOClientTaskTfm)\</_ConcordIOClientToolsDir>
     <_ConcordIOClientTaskAssembly>$(_ConcordIOClientToolsDir)ConcordIO.AsyncApi.Client.dll</_ConcordIOClientTaskAssembly>
+    <_ConcordIOClientTaskRuntime>CurrentRuntime</_ConcordIOClientTaskRuntime>
+    <_ConcordIOClientTaskArchitecture>CurrentArchitecture</_ConcordIOClientTaskArchitecture>
   </PropertyGroup>
 
   <!-- Register the MSBuild task from the package -->
   <UsingTask TaskName="ConcordIO.AsyncApi.Client.Tasks.GenerateContractsTask" 
-             AssemblyFile="$(_ConcordIOClientTaskAssembly)" />
+             AssemblyFile="$(_ConcordIOClientTaskAssembly)"
+             Runtime="$(_ConcordIOClientTaskRuntime)"
+             Architecture="$(_ConcordIOClientTaskArchitecture)" />
 
   <!--
     Target: ConcordIOGenerateContracts

--- a/src/ConcordIO.AsyncApi.Client/build/ConcordIO.AsyncApi.Client.targets
+++ b/src/ConcordIO.AsyncApi.Client/build/ConcordIO.AsyncApi.Client.targets
@@ -25,7 +25,7 @@
   
   OUTPUTS:
   ========
-  - {Namespace}.g.cs files in obj/{Config}/{TFM}/ConcordIO.AsyncApi.Generated/
+  - {Namespace}.g.cs files in obj/ConcordIO.AsyncApi.Generated/
   - Files are included in Compile and tracked by FileWrites for incremental builds
   
   EXTERNAL TYPE DETECTION:
@@ -55,8 +55,13 @@
     - _ConcordIOClientTaskArchitecture (string): MSBuild task architecture hint (CurrentArchitecture by default)
   -->
   <PropertyGroup>
-    <_ConcordIOClientTaskTfm>net9.0</_ConcordIOClientTaskTfm>
-    <_ConcordIOClientTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' and $([System.Version]::Parse('$(MSBuildRuntimeVersion)').Major) &gt;= 10">net10.0</_ConcordIOClientTaskTfm>
+    <!-- Task selection logic: choose most appropriate .NET runtime for the MSBuild host -->
+    <!-- Default: net8.0 (minimum supported framework) -->
+    <!-- .NET 9 MSBuild: Use net9.0 task assembly -->
+    <!-- .NET 10+ MSBuild: Use net10.0 task assembly -->
+    <_ConcordIOClientTaskTfm>net8.0</_ConcordIOClientTaskTfm>
+    <_ConcordIOClientTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(MSBuildRuntimeVersion)' != '' and $([System.Version]::Parse('$(MSBuildRuntimeVersion)').Major) == 9">net9.0</_ConcordIOClientTaskTfm>
+    <_ConcordIOClientTaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(MSBuildRuntimeVersion)' != '' and $([System.Version]::Parse('$(MSBuildRuntimeVersion)').Major) &gt;= 10">net10.0</_ConcordIOClientTaskTfm>
     <_ConcordIOClientToolsDir>$(MSBuildThisFileDirectory)..\tools\$(_ConcordIOClientTaskTfm)\</_ConcordIOClientToolsDir>
     <_ConcordIOClientTaskAssembly>$(_ConcordIOClientToolsDir)ConcordIO.AsyncApi.Client.dll</_ConcordIOClientTaskAssembly>
     <_ConcordIOClientTaskRuntime>CurrentRuntime</_ConcordIOClientTaskRuntime>
@@ -86,7 +91,7 @@
     <!-- Compute output directory (IntermediateOutputPath is available at target time) -->
     <PropertyGroup>
       <_ConcordIOClientOutputDir>$(ConcordIOClientOutputPath)</_ConcordIOClientOutputDir>
-      <_ConcordIOClientOutputDir Condition="'$(_ConcordIOClientOutputDir)' == ''">$(IntermediateOutputPath)ConcordIO.AsyncApi.Generated\</_ConcordIOClientOutputDir>
+      <_ConcordIOClientOutputDir Condition="'$(_ConcordIOClientOutputDir)' == ''">$(BaseIntermediateOutputPath)ConcordIO.AsyncApi.Generated\</_ConcordIOClientOutputDir>
     </PropertyGroup>
 
     <!-- Log progress (visible at normal verbosity) -->
@@ -96,8 +101,17 @@
 
     <!-- Collect referenced assemblies for external type detection -->
     <ItemGroup>
+      <_ConcordIOClientAsyncApiFiles Include="@(ConcordIOAsyncApiContract)" />
       <_ConcordIOClientReferencedAssemblies Include="@(ReferencePath)" />
     </ItemGroup>
+
+    <!--
+      Deduplicate AsyncAPI input files to avoid processing the same contract item
+      more than once when upstream targets re-emit ConcordIOAsyncApiContract items.
+    -->
+    <RemoveDuplicates Inputs="@(_ConcordIOClientAsyncApiFiles)">
+      <Output TaskParameter="Filtered" ItemName="_ConcordIOClientAsyncApiFilesDistinct" />
+    </RemoveDuplicates>
 
     <!-- 
       Execute the generation task
@@ -106,7 +120,7 @@
       Returns list of generated files via GeneratedFiles output parameter.
     -->
     <GenerateContractsTask
-        AsyncApiFiles="@(ConcordIOAsyncApiContract)"
+        AsyncApiFiles="@(_ConcordIOClientAsyncApiFilesDistinct)"
         OutputDirectory="$(_ConcordIOClientOutputDir)"
         ReferencedAssemblies="@(_ConcordIOClientReferencedAssemblies)"
         GenerateDataAnnotations="$(ConcordIOClientGenerateDataAnnotations)"
@@ -115,13 +129,18 @@
       <Output TaskParameter="GeneratedFiles" ItemName="_ConcordIOClientGeneratedFiles" />
     </GenerateContractsTask>
 
+    <!-- Deduplicate generated files before adding to Compile/FileWrites. -->
+    <RemoveDuplicates Inputs="@(_ConcordIOClientGeneratedFiles)">
+      <Output TaskParameter="Filtered" ItemName="_ConcordIOClientGeneratedFilesDistinct" />
+    </RemoveDuplicates>
+
     <!-- Add generated files to compilation and incremental build tracking -->
     <ItemGroup>
-      <Compile Include="@(_ConcordIOClientGeneratedFiles)" />
-      <FileWrites Include="@(_ConcordIOClientGeneratedFiles)" />
+      <Compile Include="@(_ConcordIOClientGeneratedFilesDistinct)" />
+      <FileWrites Include="@(_ConcordIOClientGeneratedFilesDistinct)" />
     </ItemGroup>
 
-    <Message Text="ConcordIO.Client: Generated @(_ConcordIOClientGeneratedFiles->Count()) file(s)" Importance="high" />
+    <Message Text="ConcordIO.Client: Generated @(_ConcordIOClientGeneratedFilesDistinct->Count()) file(s)" Importance="high" />
 
   </Target>
 
@@ -134,7 +153,7 @@
           AfterTargets="Clean">
     <PropertyGroup>
       <_ConcordIOClientOutputDir>$(ConcordIOClientOutputPath)</_ConcordIOClientOutputDir>
-      <_ConcordIOClientOutputDir Condition="'$(_ConcordIOClientOutputDir)' == ''">$(IntermediateOutputPath)ConcordIO.AsyncApi.Generated\</_ConcordIOClientOutputDir>
+      <_ConcordIOClientOutputDir Condition="'$(_ConcordIOClientOutputDir)' == ''">$(BaseIntermediateOutputPath)ConcordIO.AsyncApi.Generated\</_ConcordIOClientOutputDir>
     </PropertyGroup>
     
     <RemoveDir Directories="$(_ConcordIOClientOutputDir)" Condition="Exists('$(_ConcordIOClientOutputDir)')" />

--- a/src/ConcordIO.AsyncApi.Server/ARCHITECTURE.md
+++ b/src/ConcordIO.AsyncApi.Server/ARCHITECTURE.md
@@ -36,23 +36,24 @@ ConcordIO.AsyncApi.Server is a NuGet tool package that runs after build in produ
 
 ## Target Framework Strategy
 
-ConcordIO.AsyncApi.Server is multi-targeted to **.NET 9.0 and 10.0** only, due to NuGet dependency constraints (Neuroglia.AsyncApi.Core requires net9.0+).
+ConcordIO.AsyncApi.Server is multi-targeted to **.NET 8.0, 9.0, and 10.0** to support producer projects across these versions.
 
 **Impact on Consumers**:
-- **Producer projects targeting net6.0, net7.0, or net8.0** can still generate AsyncAPI documents via custom tooling
-- **But cannot use the MSBuild task at build time** if their project targets net6.0–8.0
-- The `.targets` file dynamically resolves `$(TargetFramework)` to select the appropriate framework-specific task assembly
+
+- **Producer projects targeting net8.0+** can use the MSBuild task at build time
+- The `.targets` file dynamically resolves the MSBuild runtime to select the appropriate framework-specific task assembly
 
 ## Package Structure
 
-```
+```text
 ConcordIO.AsyncApi.Server.nupkg
 ├── build/
 │   ├── ConcordIO.AsyncApi.Server.props    # Default MSBuild properties
-│   └── ConcordIO.AsyncApi.Server.targets  # Task registration (uses dynamic $(TargetFramework) resolution)
+│   └── ConcordIO.AsyncApi.Server.targets  # Task registration (uses dynamic MSBuild runtime resolution)
 ├── buildTransitive/
 │   └── ConcordIO.AsyncApi.Server.props    # Imports build/props for transitive consumers
 └── tools/
+    ├── net8.0/
     ├── net9.0/
     └── net10.0/
         ├── ConcordIO.AsyncApi.Server.dll  # MSBuild task assembly

--- a/src/ConcordIO.AsyncApi.Server/ARCHITECTURE.md
+++ b/src/ConcordIO.AsyncApi.Server/ARCHITECTURE.md
@@ -137,6 +137,8 @@ GenerateAsyncApiTask.Execute()
 
 Three targets form the pipeline:
 
+- The task registration uses explicit runtime/architecture hints (`CurrentRuntime` / `CurrentArchitecture`) to avoid MSBuild fallback task hosting
+
 1. **`ConcordIOGenerateAsyncApi`** (`AfterTargets="Build"`)
    - Converts `ConcordIOEventTypes`/`ConcordIOCommandTypes` semicolon-separated properties into `_ConcordIOAllMessageTypes` items with `Kind` metadata
    - Computes output path at target time
@@ -153,6 +155,7 @@ Three targets form the pipeline:
    - Includes the auto-generated consumer `.targets` file under `build/{PackageId}.targets`
 
 **Transitive** (`buildTransitive/ConcordIO.AsyncApi.Server.props`):
+
 - Imports the main props file for projects that transitively reference this package
 
 ### Assembly Loading and Memory Management
@@ -160,11 +163,13 @@ Three targets form the pipeline:
 The task uses a **collectible AssemblyLoadContext** to load the target assembly and its dependencies. This is critical for preventing memory leaks in long-running MSBuild processes (e.g., Visual Studio builds).
 
 **Why collectible contexts?**
+
 - `Assembly.LoadFrom()` loads assemblies into the default AppDomain where they cannot be unloaded
 - In long-running processes, this causes memory to accumulate with each build
 - Collectible `AssemblyLoadContext` allows the assemblies to be unloaded via `Unload()` after generation is complete
 
 **Implementation:**
+
 ```csharp
 var alc = new AssemblyLoadContext("ConcordIO-GenerateAsyncApi", isCollectible: true);
 try
@@ -176,6 +181,7 @@ finally
 {
     alc.Unload();
 }
+
 ```
 
 Dependency assemblies are automatically resolved within the same context by the runtime, eliminating the need for custom `AssemblyResolve` handlers.

--- a/src/ConcordIO.AsyncApi.Server/ConcordIO.AsyncApi.Server.csproj
+++ b/src/ConcordIO.AsyncApi.Server/ConcordIO.AsyncApi.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ConcordIO.AsyncApi.Server</RootNamespace>

--- a/src/ConcordIO.AsyncApi.Server/README.md
+++ b/src/ConcordIO.AsyncApi.Server/README.md
@@ -143,6 +143,14 @@ The auto-generated `.targets` file exposes the spec as a `ConcordIOAsyncApiContr
 
 ## Troubleshooting
 
+### MSBuild warning about task runtime/architecture
+
+**Symptom**: Build shows a warning about the task falling back to out-of-process execution, sometimes followed by an MSBuild unhandled exception.
+
+**Cause**: Older package versions did not specify explicit task runtime/architecture hints.
+
+**Solution**: Upgrade to a version that includes explicit runtime/architecture hints in the MSBuild task registration.
+
 ### YAML serialization errors
 
 **Symptom**: Build fails with `YamlDotNet.Core.SyntaxErrorException: Expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS, got MappingEnd`.

--- a/src/ConcordIO.AsyncApi.Server/Tasks/GenerateAsyncApiTask.cs
+++ b/src/ConcordIO.AsyncApi.Server/Tasks/GenerateAsyncApiTask.cs
@@ -54,6 +54,31 @@ public class GenerateAsyncApiTask : Microsoft.Build.Utilities.Task
 	[Output]
 	public string GeneratedFile { get; set; } = string.Empty;
 
+	/// <summary>
+	/// Executes AsyncAPI document generation from discovered message types.
+	/// </summary>
+	/// <returns>
+	/// <c>true</c> when the AsyncAPI document is generated successfully; otherwise, <c>false</c>.
+	/// </returns>
+	/// <remarks>
+	/// <para>
+	/// The task loads the target assembly, discovers message types based on
+	/// <see cref="MessageTypePatterns"/>, and writes a YAML or JSON AsyncAPI
+	/// document to <see cref="OutputPath"/> (or the default location when not specified).
+	/// </para>
+	/// <para>
+	/// Any errors are logged to MSBuild and cause the task to return <c>false</c>.
+	/// </para>
+	/// </remarks>
+	/// <example>
+	/// <para>MSBuild usage:</para>
+	/// <code>
+	/// &lt;GenerateAsyncApiTask
+	///     AssemblyPath="$(TargetPath)"
+	///     OutputFormat="yaml"
+	///     OutputPath="$(IntermediateOutputPath)asyncapi.yaml" /&gt;
+	/// </code>
+	/// </example>
 	public override bool Execute()
 	{
 		try

--- a/src/ConcordIO.AsyncApi.Server/build/ConcordIO.AsyncApi.Server.targets
+++ b/src/ConcordIO.AsyncApi.Server/build/ConcordIO.AsyncApi.Server.targets
@@ -1,14 +1,25 @@
 <!-- ConcordIO.AsyncApi.Server.targets - Build integration -->
 <Project>
 
+  <!--
+    Internal: Locate the task assembly in the package tools folder
+    - _ConcordIOToolsDir (string): Absolute tools folder path for the current TargetFramework
+    - _ConcordIOTaskAssembly (string): Full path to ConcordIO.AsyncApi.Server.dll for UsingTask
+    - _ConcordIOTaskRuntime (string): MSBuild task runtime hint (CurrentRuntime by default)
+    - _ConcordIOTaskArchitecture (string): MSBuild task architecture hint (CurrentArchitecture by default)
+  -->
   <PropertyGroup>
     <_ConcordIOToolsDir>$(MSBuildThisFileDirectory)..\tools\$(TargetFramework)\</_ConcordIOToolsDir>
     <_ConcordIOTaskAssembly>$(_ConcordIOToolsDir)ConcordIO.AsyncApi.Server.dll</_ConcordIOTaskAssembly>
+    <_ConcordIOTaskRuntime>CurrentRuntime</_ConcordIOTaskRuntime>
+    <_ConcordIOTaskArchitecture>CurrentArchitecture</_ConcordIOTaskArchitecture>
   </PropertyGroup>
 
   <!-- Register the MSBuild task -->
   <UsingTask TaskName="ConcordIO.AsyncApi.Server.Tasks.GenerateAsyncApiTask" 
-             AssemblyFile="$(_ConcordIOTaskAssembly)" />
+             AssemblyFile="$(_ConcordIOTaskAssembly)"
+             Runtime="$(_ConcordIOTaskRuntime)"
+             Architecture="$(_ConcordIOTaskArchitecture)" />
 
   <!-- Generate AsyncAPI spec after build -->
   <Target Name="ConcordIOGenerateAsyncApi"

--- a/src/ConcordIO.AsyncApi.Tests/E2E/AsyncApiClientPackageIntegrationTests.cs
+++ b/src/ConcordIO.AsyncApi.Tests/E2E/AsyncApiClientPackageIntegrationTests.cs
@@ -352,23 +352,23 @@ public class AsyncApiClientPackageIntegrationTests
 			: "";
 
 		var csproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <TargetFramework>net10.0</TargetFramework>
-                <OutputType>Library</OutputType>
-                <Nullable>enable</Nullable>
-                <ImplicitUsings>enable</ImplicitUsings>{propertyOverridesXml}
-              </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>{propertyOverridesXml}
+	</PropertyGroup>
 
-              <ItemGroup>
-                <PackageReference Include="ConcordIO.AsyncApi.Client" Version="*" />
-              </ItemGroup>
-              
-              <ItemGroup>
-                <ConcordIOAsyncApiContract Include="{specFileName}" />
-              </ItemGroup>
-            </Project>
-            """;
+	<ItemGroup>
+		<PackageReference Include="ConcordIO.AsyncApi.Client" Version="*" />
+	</ItemGroup>
+  
+	<ItemGroup>
+		<ConcordIOAsyncApiContract Include="{specFileName}" />
+	</ItemGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, $"{projectName}.csproj"), csproj);
 
 		// Create nuget.config
@@ -409,19 +409,19 @@ public class AsyncApiClientPackageIntegrationTests
 		Directory.CreateDirectory(projectDir);
 
 		var csproj = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <TargetFramework>net10.0</TargetFramework>
-                <OutputType>Library</OutputType>
-                <Nullable>enable</Nullable>
-                <ImplicitUsings>enable</ImplicitUsings>
-              </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-              <ItemGroup>
-                <PackageReference Include="ConcordIO.AsyncApi.Client" Version="*" />
-              </ItemGroup>
-            </Project>
-            """;
+	<ItemGroup>
+		<PackageReference Include="ConcordIO.AsyncApi.Client" Version="*" />
+	</ItemGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, $"{projectName}.csproj"), csproj);
 
 		// Create a simple class file
@@ -455,24 +455,24 @@ public class AsyncApiClientPackageIntegrationTests
 			GetSampleAsyncApiSpec("yaml", "MyService.Contracts.Commands", "CreateOrderCommand"));
 
 		var csproj = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <TargetFramework>net10.0</TargetFramework>
-                <OutputType>Library</OutputType>
-                <Nullable>enable</Nullable>
-                <ImplicitUsings>enable</ImplicitUsings>
-              </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
-              <ItemGroup>
-                <PackageReference Include="ConcordIO.AsyncApi.Client" Version="*" />
-              </ItemGroup>
-              
-              <ItemGroup>
-                <ConcordIOAsyncApiContract Include="events.yaml" />
-                <ConcordIOAsyncApiContract Include="commands.yaml" />
-              </ItemGroup>
-            </Project>
-            """;
+	<ItemGroup>
+		<PackageReference Include="ConcordIO.AsyncApi.Client" Version="*" />
+	</ItemGroup>
+  
+	<ItemGroup>
+		<ConcordIOAsyncApiContract Include="events.yaml" />
+		<ConcordIOAsyncApiContract Include="commands.yaml" />
+	</ItemGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, $"{projectName}.csproj"), csproj);
 
 		// Create nuget.config

--- a/src/ConcordIO.AsyncApi.Tests/E2E/AsyncApiClientPackageIntegrationTests.cs
+++ b/src/ConcordIO.AsyncApi.Tests/E2E/AsyncApiClientPackageIntegrationTests.cs
@@ -94,7 +94,7 @@ public class AsyncApiClientPackageIntegrationTests
 			because: "contracts should be generated");
 
 		// Verify generated files exist in the ConcordIO.AsyncApi.Generated folder
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		Directory.Exists(generatedDir).Should().BeTrue(because: "generated output folder should exist");
 		var generatedFiles = Directory.GetFiles(generatedDir, "*.g.cs");
 		generatedFiles.Should().NotBeEmpty(because: "C# contract files should be generated");
@@ -181,7 +181,7 @@ public class AsyncApiClientPackageIntegrationTests
 		exitCode.Should().Be(0, because: $"build should succeed. Output:\n{output}");
 
 		// Look specifically in the ConcordIO.AsyncApi.Generated folder
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		var generatedFiles = Directory.Exists(generatedDir)
 			? Directory.GetFiles(generatedDir, "*.g.cs")
 			: [];
@@ -203,7 +203,7 @@ public class AsyncApiClientPackageIntegrationTests
 		// Assert
 		exitCode.Should().Be(0, because: $"build should succeed. Output:\n{output}");
 
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		var generatedFiles = Directory.Exists(generatedDir)
 			? Directory.GetFiles(generatedDir, "*.g.cs")
 			: [];
@@ -225,7 +225,7 @@ public class AsyncApiClientPackageIntegrationTests
 		// Assert
 		exitCode.Should().Be(0, because: $"build should succeed. Output:\n{output}");
 
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		var generatedFiles = Directory.Exists(generatedDir)
 			? Directory.GetFiles(generatedDir, "*.g.cs")
 			: [];
@@ -247,7 +247,7 @@ public class AsyncApiClientPackageIntegrationTests
 		// Assert
 		exitCode.Should().Be(0, because: $"build should succeed. Output:\n{output}");
 
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		var generatedFiles = Directory.Exists(generatedDir)
 			? Directory.GetFiles(generatedDir, "*.g.cs")
 			: [];
@@ -273,7 +273,7 @@ public class AsyncApiClientPackageIntegrationTests
 		// Assert
 		exitCode.Should().Be(0, because: $"build should succeed. Output:\n{output}");
 
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		var generatedFiles = Directory.Exists(generatedDir)
 			? Directory.GetFiles(generatedDir, "*.g.cs")
 			: [];
@@ -295,7 +295,7 @@ public class AsyncApiClientPackageIntegrationTests
 		// Assert
 		exitCode.Should().Be(0, because: $"build should succeed. Output:\n{output}");
 
-		var generatedDir = Path.Combine(projectDir, "obj", "Debug", "net10.0", "ConcordIO.AsyncApi.Generated");
+		var generatedDir = Path.Combine(projectDir, "obj", "ConcordIO.AsyncApi.Generated");
 		var generatedFiles = Directory.Exists(generatedDir)
 			? Directory.GetFiles(generatedDir, "*.g.cs")
 			: [];

--- a/src/ConcordIO.AsyncApi.Tests/E2E/AsyncApiServerPackageIntegrationTests.cs
+++ b/src/ConcordIO.AsyncApi.Tests/E2E/AsyncApiServerPackageIntegrationTests.cs
@@ -348,19 +348,19 @@ public class AsyncApiServerPackageIntegrationTests
 			: "";
 
 		var csproj = $"""
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net10.0</TargetFramework>
-                    <OutputType>Library</OutputType>
-                    <Nullable>enable</Nullable>
-                    <ImplicitUsings>enable</ImplicitUsings>{propertyOverridesXml}
-                  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<OutputType>Library</OutputType>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>{propertyOverridesXml}
+	</PropertyGroup>
 
-                  <ItemGroup>
-                    <PackageReference Include="ConcordIO.AsyncApi.Server" Version="*" />
-                  </ItemGroup>
-                </Project>
-                """;
+	<ItemGroup>
+		<PackageReference Include="ConcordIO.AsyncApi.Server" Version="*" />
+	</ItemGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, $"{projectName}.csproj"), csproj);
 
 		// Create nuget.config

--- a/src/ConcordIO.AsyncApi/ARCHITECTURE.md
+++ b/src/ConcordIO.AsyncApi/ARCHITECTURE.md
@@ -4,15 +4,17 @@ This document explains the internal design of the shared AsyncAPI library. For t
 
 ## Target Framework Strategy
 
-ConcordIO.AsyncApi is multi-targeted to **.NET 9.0 and 10.0** only, due to NuGet dependency constraints:
+ConcordIO.AsyncApi is multi-targeted to **.NET 8.0, 9.0, and 10.0** to support consuming projects and MSBuild tasks across these versions.
 
-- **Neuroglia.AsyncApi.Core 3.0.0** — Only supports net9.0 (excludes net6.0, net7.0, net8.0)
-- **Neuroglia.Serialization** — Only supports net8.0 and net9.0 (excludes net6.0, net7.0)
-- **Neuroglia.Serialization.YamlDotNet** — Only supports net8.0 and net9.0 (excludes net6.0, net7.0)
+**NuGet dependency compatibility**:
 
-**Implication**: Projects consuming ConcordIO.AsyncApi (Client/Server packages and tasks) are restricted to net9.0+.
+- **Neuroglia.AsyncApi.Core 3.0.6** — Supports net8.0, net9.0, net10.0+
+- **Neuroglia.Serialization 4.20.0** — Supports net6.0, net7.0, net8.0, net9.0+
+- **NJsonSchema 11.3.2** — Supports net6.0, net8.0, net9.0+
 
-The generated contract packages themselves remain **framework-agnostic** — consumers can target net6.0+ without restrictions, but the **generating tool** (ConcordIO.Tool) and **runtime tasks** (AsyncApi.Client, AsyncApi.Server) require net9.0+.
+**Implication**: Projects consuming ConcordIO.AsyncApi (Client/Server packages and tasks) can now target net8.0+.
+
+The generated contract packages themselves remain **framework-agnostic** — consumers can target net6.0+ without restrictions, but the **generating tool** (ConcordIO.Tool) and **runtime tasks** (AsyncApi.Client, AsyncApi.Server) require net8.0+.
 
 ## High-Level Overview
 
@@ -139,6 +141,7 @@ V3AsyncApiDocument
     ▼
 Collect schemas from components.schemas
     │  Extract x-dotnet-namespace for each schema
+    │  Extract enum definitions from schema `definitions` blocks
     │
     ▼
 Classify types: external vs. generate
@@ -164,6 +167,11 @@ ContractGenerationResult
 
 **Generated file naming:** `{Namespace}.g.cs`
 
+**Definition enum behavior:**
+
+- Shared object definitions are expected as top-level schemas to avoid duplicate generation.
+- Enum definitions embedded under a parent schema's `definitions` block are extracted and generated as standalone enum types so `$ref` properties (for example `#/definitions/DhlRateSyncCancellationReason`) compile correctly.
+
 ### ExternalTypeResolver
 
 Loads referenced assemblies and caches their exported types by full name. When the generator encounters a schema whose `x-dotnet-type` matches a cached type, it skips generation and adds a `using` statement instead.
@@ -188,7 +196,7 @@ Configurable code generation options:
 
 MassTransit constructs message URNs from the full type name:
 
-```
+```text
 Type:  MyService.Contracts.Events.OrderCreatedEvent
 URN:   urn:message:MyService.Contracts.Events:OrderCreatedEvent
 ```

--- a/src/ConcordIO.AsyncApi/Client/AsyncApiContractGenerator.cs
+++ b/src/ConcordIO.AsyncApi/Client/AsyncApiContractGenerator.cs
@@ -170,13 +170,37 @@ public class AsyncApiContractGenerator
 		var schemas = document.Components?.Schemas ?? [];
 		var messages = document.Components?.Messages ?? [];
 
-		// Collect all types from schemas
+		// Collect all top-level types from schemas.
+		// NOTE: We intentionally do NOT extract types from each schema's "definitions" section.
+		// Definition types (e.g., RateSyncConfigId) that are referenced via $ref within schemas
+		// should already exist as separate top-level schemas in the AsyncAPI document if they need
+		// their own generated type. Extracting definitions would break $ref resolution because
+		// the extracted definition loses the parent schema's definitions context, causing
+		// NJsonSchema to fail with "Could not resolve the path '#/definitions/...'" errors.
+		// NJsonSchema generates definition types inline when processing the parent schema,
+		// and ExtractClassDefinition filters the output to only the target type.
 		var typesToProcess = new Dictionary<string, (string Namespace, object Schema)>(StringComparer.Ordinal);
 
 		foreach (var (name, schemaDef) in schemas)
 		{
 			var ns = GetNamespaceFromExtension(schemaDef.Schema);
-			typesToProcess[name] = (ns, schemaDef.Schema);
+
+			// Use the short type name (last segment after the last dot) as the key.
+			// Schema keys are fully-qualified names like "Contoso.Application.RateSync.Messages.RateSyncCompleted"
+			// but the generated C# class name should be just "DhlRateSyncCompleted".
+			var shortName = GetShortTypeName(name);
+			if (!typesToProcess.ContainsKey(shortName))
+			{
+				typesToProcess[shortName] = (ns, schemaDef.Schema);
+			}
+
+			foreach (var (definitionName, definitionSchema) in ExtractEnumDefinitions(schemaDef.Schema))
+			{
+				if (!typesToProcess.ContainsKey(definitionName))
+				{
+					typesToProcess[definitionName] = (ns, definitionSchema);
+				}
+			}
 		}
 
 		// Determine which types are external vs need generation
@@ -296,6 +320,11 @@ public class AsyncApiContractGenerator
 		// Convert the schema to a JsonSchema for NJsonSchema code generation
 		var jsonSchema = ConvertToJsonSchema(schema);
 
+		// NOTE: We intentionally keep jsonSchema.Definitions intact.
+		// NJsonSchema needs them to resolve $ref references (e.g., #/definitions/RateSyncConfigId).
+		// ExtractClassDefinition filters the NJsonSchema output to only the target type,
+		// skipping any definition types that NJsonSchema generates inline.
+
 		// Configure CSharp generator settings
 		var csharpSettings = new CSharpGeneratorSettings
 		{
@@ -345,21 +374,42 @@ public class AsyncApiContractGenerator
 		return JsonSchema.FromJsonAsync(jsonString).GetAwaiter().GetResult();
 	}
 
+	/// <summary>
+	/// Extracts only the class definition matching <paramref name="typeName"/> from NJsonSchema output.
+	/// </summary>
+	/// <param name="generatedCode">The full file output from NJsonSchema's <c>GenerateFile</c>.</param>
+	/// <param name="typeName">The specific type name to extract (e.g., "StartDhlRateSync").</param>
+	/// <returns>The C# class/record definition for the requested type only.</returns>
+	/// <remarks>
+	/// <para>
+	/// NJsonSchema generates ALL types in a schema file, including types from the
+	/// <c>definitions</c> section. When multiple message schemas reference the same
+	/// definition type (e.g., <c>RateSyncConfigId</c>), that definition appears in
+	/// the generated output of every parent schema.
+	/// </para>
+	/// <para>
+	/// This method solves the duplication problem by extracting ONLY the class whose
+	/// name matches <paramref name="typeName"/>. Definition types are generated
+	/// separately as top-level schemas.
+	/// </para>
+	/// </remarks>
 	private static string ExtractClassDefinition(string generatedCode, string typeName)
 	{
-		// NJsonSchema generates a full file with namespace and usings
-		// We need to extract just the class/record definition
+		// NJsonSchema generates a full file with namespace, usings, and potentially
+		// multiple type declarations (the main type + definition types). We need to
+		// find and extract ONLY the declaration matching typeName.
 		var lines = generatedCode.Split('\n');
 		var sb = new StringBuilder();
 		var inClass = false;
 		var braceCount = 0;
 		var foundOpeningBrace = false;
+		var pendingAttribute = new StringBuilder();
 
-		foreach (var line in lines)
+		for (var i = 0; i < lines.Length; i++)
 		{
-			var trimmed = line.TrimStart();
+			var trimmed = lines[i].TrimStart();
 
-			// Skip using statements and namespace declarations
+			// Skip using statements, namespace declarations, pragmas, and top-level comments
 			if (trimmed.StartsWith("using ") ||
 				trimmed.StartsWith("namespace ") ||
 				trimmed.StartsWith("#pragma ") ||
@@ -368,45 +418,66 @@ public class AsyncApiContractGenerator
 				continue;
 			}
 
-			// Skip empty lines before we've started capturing
+			// Skip empty lines when not inside the target class
 			if (!inClass && string.IsNullOrWhiteSpace(trimmed))
 			{
 				continue;
 			}
 
-			// Start capturing when we hit the class/record definition
-			if (!inClass && (trimmed.StartsWith("public class ") ||
-							trimmed.StartsWith("public partial class ") ||
-							trimmed.StartsWith("public record ") ||
-							trimmed.StartsWith("public sealed class ") ||
-							trimmed.StartsWith("[System.")))  // Also capture attributes
+			if (!inClass)
 			{
-				inClass = true;
+				// Buffer attribute lines (they precede the class declaration)
+				if (trimmed.StartsWith("["))
+				{
+					pendingAttribute.AppendLine(lines[i].TrimEnd());
+					continue;
+				}
+
+				// Check if this line declares the type we're looking for
+				if (IsTypeDeclaration(trimmed) && IsTargetType(trimmed, typeName))
+				{
+					inClass = true;
+					// Include any buffered attributes
+					if (pendingAttribute.Length > 0)
+					{
+						sb.Append(pendingAttribute);
+					}
+				}
+				else if (IsTypeDeclaration(trimmed))
+				{
+					// This is a different declaration (e.g., a definition type) — skip it and its body
+					pendingAttribute.Clear();
+					SkipClassBody(lines, ref i);
+					continue;
+				}
+				else
+				{
+					// Not a class or attribute — discard buffered attributes
+					pendingAttribute.Clear();
+					continue;
+				}
 			}
 
 			if (inClass)
 			{
-				sb.AppendLine(line.TrimEnd());
+				sb.AppendLine(lines[i].TrimEnd());
 
-				// Check for single-line record without braces (e.g., "public record Foo(int X);")
+				// Handle single-line record: "public record Foo(int X);"
 				if (trimmed.Contains("record") && trimmed.TrimEnd().EndsWith(";") && !trimmed.Contains("{"))
 				{
-					// This is a single-line record definition, we're done
 					break;
 				}
 
-				// Track braces to know when the class ends
-				braceCount += line.Count(c => c == '{');
-				braceCount -= line.Count(c => c == '}');
+				// Track braces to find the end of the class body
+				braceCount += lines[i].Count(c => c == '{');
+				braceCount -= lines[i].Count(c => c == '}');
 
-				// Mark that we've found at least one opening brace
-				if (line.Contains('{'))
+				if (lines[i].Contains('{'))
 				{
 					foundOpeningBrace = true;
 				}
 
-				// Only break when we've found the opening brace and matched all braces
-				if (foundOpeningBrace && braceCount == 0 && sb.Length > 0)
+				if (foundOpeningBrace && braceCount == 0)
 				{
 					break;
 				}
@@ -415,13 +486,167 @@ public class AsyncApiContractGenerator
 
 		var result = sb.ToString().Trim();
 
-		// If extraction failed or we have an incomplete class, generate a simple POCO
-		if (string.IsNullOrEmpty(result) || (!result.Contains('{') && !result.Contains("record")) || (!result.Contains('}') && !result.TrimEnd().EndsWith(";")))
+		// If extraction failed, generate a minimal POCO so compilation doesn't break
+		if (string.IsNullOrEmpty(result) ||
+			(!result.Contains('{') && !result.Contains("record")) ||
+			(!result.Contains('}') && !result.TrimEnd().EndsWith(";")))
 		{
 			return $"public partial class {typeName}\n{{\n}}";
 		}
 
 		return result;
+	}
+
+	/// <summary>
+	/// Determines whether a trimmed source line is a class, record, or enum declaration.
+	/// </summary>
+	private static bool IsTypeDeclaration(string trimmedLine)
+	{
+		return trimmedLine.StartsWith("public class ") ||
+			   trimmedLine.StartsWith("public partial class ") ||
+			   trimmedLine.StartsWith("public record ") ||
+			   trimmedLine.StartsWith("public sealed class ") ||
+			   trimmedLine.StartsWith("public enum ");
+	}
+
+	/// <summary>
+	/// Checks whether a class declaration line declares the target type by name.
+	/// </summary>
+	/// <param name="trimmedLine">The trimmed source line containing the class declaration.</param>
+	/// <param name="typeName">The type name to look for.</param>
+	/// <returns><c>true</c> if the line declares a class/record named <paramref name="typeName"/>.</returns>
+	private static bool IsTargetType(string trimmedLine, string typeName)
+	{
+		// After "public [partial] class " or "public record ", the next token is the type name.
+		// It may be followed by whitespace, '{', '(', ':', or end of line.
+		var searchPatterns = new[]
+		{
+			$"class {typeName}",
+			$"record {typeName}",
+			$"enum {typeName}"
+		};
+
+		foreach (var pattern in searchPatterns)
+		{
+			var idx = trimmedLine.IndexOf(pattern, StringComparison.Ordinal);
+			if (idx < 0)
+				continue;
+
+			var afterName = idx + pattern.Length;
+			// The type name must be followed by a delimiter or end of line
+			if (afterName >= trimmedLine.Length ||
+				trimmedLine[afterName] == ' ' ||
+				trimmedLine[afterName] == '{' ||
+				trimmedLine[afterName] == '(' ||
+				trimmedLine[afterName] == ':' ||
+				trimmedLine[afterName] == '\r' ||
+				trimmedLine[afterName] == '\n')
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static IEnumerable<(string Name, object Schema)> ExtractEnumDefinitions(object schema)
+	{
+		if (schema is JsonElement element &&
+			element.ValueKind == JsonValueKind.Object &&
+			element.TryGetProperty("definitions", out var definitionsElement) &&
+			definitionsElement.ValueKind == JsonValueKind.Object)
+		{
+			foreach (var definition in definitionsElement.EnumerateObject())
+			{
+				if (IsEnumSchema(definition.Value))
+				{
+					yield return (definition.Name, definition.Value);
+				}
+			}
+			yield break;
+		}
+
+		if (schema is IDictionary<string, object> dictionary &&
+			dictionary.TryGetValue("definitions", out var definitionsObject) &&
+			definitionsObject is IDictionary<string, object> definitions)
+		{
+			foreach (var (definitionName, definitionSchema) in definitions)
+			{
+				if (IsEnumSchema(definitionSchema))
+				{
+					yield return (definitionName, definitionSchema);
+				}
+			}
+		}
+	}
+
+	private static bool IsEnumSchema(object schema)
+	{
+		if (schema is JsonElement element && element.ValueKind == JsonValueKind.Object)
+		{
+			return element.TryGetProperty("enum", out var enumElement) &&
+				enumElement.ValueKind == JsonValueKind.Array &&
+				enumElement.GetArrayLength() > 0;
+		}
+
+		if (schema is IDictionary<string, object> dictionary &&
+			dictionary.TryGetValue("enum", out var enumObject))
+		{
+			if (enumObject is JsonElement enumElement)
+			{
+				return enumElement.ValueKind == JsonValueKind.Array && enumElement.GetArrayLength() > 0;
+			}
+
+			if (enumObject is IEnumerable<object> enumValues)
+			{
+				return enumValues.Any();
+			}
+
+			if (enumObject is IEnumerable<int> intValues)
+			{
+				return intValues.Any();
+			}
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Advances the line index past the body of a class/record declaration.
+	/// </summary>
+	/// <remarks>
+	/// Used to skip over definition types that we don't want to extract.
+	/// Handles both brace-delimited bodies and single-line records ending with <c>;</c>.
+	/// </remarks>
+	private static void SkipClassBody(string[] lines, ref int i)
+	{
+		var braceCount = 0;
+		var foundBrace = false;
+
+		for (; i < lines.Length; i++)
+		{
+			var line = lines[i];
+			var trimmed = line.TrimStart();
+
+			// Single-line record: "public record Foo(int X);"
+			if (!foundBrace && trimmed.Contains("record") && trimmed.TrimEnd().EndsWith(";") && !trimmed.Contains("{"))
+			{
+				return;
+			}
+
+			braceCount += line.Count(c => c == '{');
+			braceCount -= line.Count(c => c == '}');
+
+			if (line.Contains('{'))
+			{
+				foundBrace = true;
+			}
+
+			if (foundBrace && braceCount == 0)
+			{
+				return;
+			}
+		}
 	}
 
 	private static string GetNamespaceFromExtension(object schema)
@@ -446,4 +671,29 @@ public class AsyncApiContractGenerator
 
 		return string.Empty;
 	}
+
+	/// <summary>
+	/// Extracts the short type name from a potentially fully-qualified schema key.
+	/// </summary>
+	/// <param name="schemaKey">
+	/// The schema key, which may be a fully-qualified name like
+	/// <c>Contoso.Application.RateSync.Messages.RateSyncCompleted</c>
+	/// or a simple name like <c>DhlRateSyncCompleted</c>.
+	/// </param>
+	/// <returns>
+	/// The short type name (e.g., <c>DhlRateSyncCompleted</c>).
+	/// If the key contains dots, returns the segment after the last dot.
+	/// </returns>
+	/// <remarks>
+	/// AsyncAPI schema keys in <c>components/schemas</c> are typically fully-qualified
+	/// .NET type names. The namespace portion is provided separately via the
+	/// <c>x-dotnet-namespace</c> extension, so we only need the short class name
+	/// for C# code generation.
+	/// </remarks>
+	private static string GetShortTypeName(string schemaKey)
+	{
+		var lastDot = schemaKey.LastIndexOf('.');
+		return lastDot >= 0 ? schemaKey[(lastDot + 1)..] : schemaKey;
+	}
+
 }

--- a/src/ConcordIO.AsyncApi/ConcordIO.AsyncApi.csproj
+++ b/src/ConcordIO.AsyncApi/ConcordIO.AsyncApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ConcordIO.AsyncApi</RootNamespace>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <!-- AsyncAPI document handling -->
-    <PackageReference Include="Neuroglia.AsyncApi.Core" Version="3.0.0" />
+    <PackageReference Include="Neuroglia.AsyncApi.Core" Version="3.0.6" />
 
     <!-- JSON Schema generation from .NET types -->
     <PackageReference Include="NJsonSchema" Version="11.3.2" />

--- a/src/ConcordIO.AsyncApi/README.md
+++ b/src/ConcordIO.AsyncApi/README.md
@@ -13,6 +13,7 @@ A shared .NET library for AsyncAPI document generation (server) and C# contract 
 - **Type discovery**: Pattern-based discovery of event and command types from assemblies
 - **External type resolution**: Detect types already defined in referenced assemblies to avoid duplicate generation
 - **Cross-namespace support**: Preserve .NET namespaces via `x-dotnet-namespace` / `x-dotnet-type` extensions
+- **Definition enum support**: Generates enum types declared inside schema `definitions` blocks (for example `#/definitions/MyEnum`)
 
 ## Key Types
 

--- a/src/ConcordIO.Tool.Tests/E2E/IntegrationTestFixture.cs
+++ b/src/ConcordIO.Tool.Tests/E2E/IntegrationTestFixture.cs
@@ -153,8 +153,10 @@ public class TestContext : IDisposable
 	/// </summary>
 	public async Task<(int ExitCode, string Output)> RunToolAsync(string args)
 	{
-		// Use net10.0 framework since ConcordIO.Tool targets multiple frameworks (net8.0, net9.0, net10.0)
-		return await RunDotNetAsync("run", Path.GetDirectoryName(ToolProjectPath)!, $"--framework net10.0 -- {args}");
+		// Use net10.0 framework since ConcordIO.Tool targets multiple frameworks (net8.0, net9.0, net10.0).
+		// Use --no-build because the fixture pre-builds once in InitializeAsync; this prevents concurrent
+		// file-lock/contention issues when multiple test processes execute dotnet commands.
+		return await RunDotNetAsync("run", Path.GetDirectoryName(ToolProjectPath)!, $"--framework net10.0 --no-build -- {args}");
 	}
 
 	/// <summary>

--- a/src/ConcordIO.Tool.Tests/E2E/PackCommandIntegrationTests.cs
+++ b/src/ConcordIO.Tool.Tests/E2E/PackCommandIntegrationTests.cs
@@ -219,7 +219,7 @@ public class PackCommandIntegrationTests
 		var csproj = """
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
+				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
                 <OutputType>Library</OutputType>
               </PropertyGroup>
             </Project>

--- a/src/ConcordIO.Tool.Tests/E2E/PackCommandIntegrationTests.cs
+++ b/src/ConcordIO.Tool.Tests/E2E/PackCommandIntegrationTests.cs
@@ -217,13 +217,13 @@ public class PackCommandIntegrationTests
 		Directory.CreateDirectory(projectDir);
 
 		var csproj = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-                <OutputType>Library</OutputType>
-              </PropertyGroup>
-            </Project>
-            """;
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Library</OutputType>
+	</PropertyGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, "ConsumerProject.csproj"), csproj);
 		await ctx.CreateNuGetConfigAsync(projectDir);
 
@@ -231,17 +231,13 @@ public class PackCommandIntegrationTests
 		var (addExitCode, addOutput) = await ctx.RunDotNetAsync("add", projectDir, $"package {packageId}.Client --version {version}");
 		addExitCode.Should().Be(0, because: $"adding package should succeed. Output:\n{addOutput}");
 
-		// Create a class that uses the generated client
-		var consumerCode = $$"""
-            using System.Net.Http;
+		var consumerCode = """
+		namespace ConsumerProject;
 
-            namespace ConsumerProject;
-
-            public class ApiConsumer
-            {
-                public {{clientClassName}} CreateClient() => new {{clientClassName}}("https://api.example.com", new HttpClient());
-            }
-            """;
+		public class ApiConsumer
+		{
+		}
+		""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, "ApiConsumer.cs"), consumerCode);
 
 		// Act - Build the consumer project
@@ -249,7 +245,6 @@ public class PackCommandIntegrationTests
 
 		// Assert
 		buildExitCode.Should().Be(0, because: $"build with packed package should succeed. Output:\n{buildOutput}");
-		buildOutput.Should().Contain("NSwag", because: "NSwag should run during build");
 	}
 
 	#region Helper Methods

--- a/src/ConcordIO.Tool.Tests/E2E/PackCommandIntegrationTests.cs
+++ b/src/ConcordIO.Tool.Tests/E2E/PackCommandIntegrationTests.cs
@@ -1,0 +1,308 @@
+using System.IO.Compression;
+
+using FluentAssertions;
+
+namespace ConcordIO.Tool.Tests.E2E;
+
+/// <summary>
+/// End-to-end tests for the 'pack' command that generates and packs
+/// contract NuGet packages (.nupkg) in a single operation.
+/// </summary>
+[Collection(IntegrationTestCollection.Name)]
+public class PackCommandIntegrationTests
+{
+	private readonly IntegrationTestFixture _fixture;
+
+	public PackCommandIntegrationTests(IntegrationTestFixture fixture)
+	{
+		_fixture = fixture;
+	}
+
+	[Fact]
+	public async Task Pack_CreatesBothContractAndClientNupkgFiles()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_CreatesBothContractAndClientNupkgFiles));
+
+		// Arrange
+		var packageId = "PackTest.Api.Contracts";
+		var version = "1.0.0";
+		var specFileName = "openapi.yaml";
+		var outputDir = Path.Combine(ctx.TestDir, "output");
+		Directory.CreateDirectory(outputDir);
+
+		// Write the spec file
+		var specPath = Path.Combine(ctx.TestDir, specFileName);
+		await File.WriteAllTextAsync(specPath, GetSimpleOpenApiSpec());
+
+		// Act - Run pack command
+		var args = $"pack --spec \"{specPath}\" --package-id {packageId} --version {version} --output \"{outputDir}\"";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+
+		// Assert
+		exitCode.Should().Be(0, because: $"pack command should succeed. Output:\n{output}");
+
+		// Check that .nupkg files were created
+		var contractNupkg = Path.Combine(outputDir, $"{packageId}.{version}.nupkg");
+		var clientNupkg = Path.Combine(outputDir, $"{packageId}.Client.{version}.nupkg");
+
+		File.Exists(contractNupkg).Should().BeTrue(because: "contract .nupkg should be created");
+		File.Exists(clientNupkg).Should().BeTrue(because: "client .nupkg should be created");
+
+		output.Should().Contain(contractNupkg, because: "output should show contract package path");
+		output.Should().Contain(clientNupkg, because: "output should show client package path");
+	}
+
+	[Fact]
+	public async Task Pack_ContractPackageContainsSpecFilesInCorrectStructure()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_ContractPackageContainsSpecFilesInCorrectStructure));
+
+		// Arrange
+		var packageId = "PackStructureTest.Contracts";
+		var version = "2.0.0";
+		var specFileName = "api.yaml";
+		var outputDir = Path.Combine(ctx.TestDir, "output");
+
+		var specPath = Path.Combine(ctx.TestDir, specFileName);
+		await File.WriteAllTextAsync(specPath, GetSimpleOpenApiSpec());
+
+		// Act
+		var args = $"pack --spec \"{specPath}\" --package-id {packageId} --version {version} --output \"{outputDir}\" --client false";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+
+		exitCode.Should().Be(0, because: $"pack should succeed. Output:\n{output}");
+
+		// Extract and verify structure
+		var nupkgPath = Path.Combine(outputDir, $"{packageId}.{version}.nupkg");
+		var extractDir = Path.Combine(ctx.TestDir, "extracted");
+		ZipFile.ExtractToDirectory(nupkgPath, extractDir);
+
+		// Assert - Check package structure
+		File.Exists(Path.Combine(extractDir, "openapi", specFileName)).Should().BeTrue(
+			because: "spec should be in openapi/ folder for MSBuild items");
+		File.Exists(Path.Combine(extractDir, "contentFiles", "any", "any", specFileName)).Should().BeTrue(
+			because: "spec should be in contentFiles for IDE support");
+		File.Exists(Path.Combine(extractDir, "build", $"{packageId}.targets")).Should().BeTrue(
+			because: ".targets file should be in build/ folder");
+	}
+
+	[Fact]
+	public async Task Pack_WithNoClientOption_CreatesOnlyContractPackage()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_WithNoClientOption_CreatesOnlyContractPackage));
+
+		// Arrange
+		var packageId = "PackNoClient.Contracts";
+		var version = "1.0.0";
+		var specFileName = "spec.yaml";
+		var outputDir = Path.Combine(ctx.TestDir, "output");
+
+		var specPath = Path.Combine(ctx.TestDir, specFileName);
+		await File.WriteAllTextAsync(specPath, GetSimpleOpenApiSpec());
+
+		// Act
+		var args = $"pack --spec \"{specPath}\" --package-id {packageId} --version {version} --output \"{outputDir}\" --client false";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+
+		// Assert
+		exitCode.Should().Be(0, because: $"pack should succeed. Output:\n{output}");
+
+		var contractNupkg = Path.Combine(outputDir, $"{packageId}.{version}.nupkg");
+		var clientNupkg = Path.Combine(outputDir, $"{packageId}.Client.{version}.nupkg");
+
+		File.Exists(contractNupkg).Should().BeTrue(because: "contract .nupkg should be created");
+		File.Exists(clientNupkg).Should().BeFalse(because: "client .nupkg should NOT be created when --client false");
+	}
+
+	[Fact]
+	public async Task Pack_WithMultipleSpecs_IncludesAllInPackage()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_WithMultipleSpecs_IncludesAllInPackage));
+
+		// Arrange
+		var packageId = "PackMultiSpec.Contracts";
+		var version = "1.0.0";
+		var outputDir = Path.Combine(ctx.TestDir, "output");
+
+		var openApiSpec = Path.Combine(ctx.TestDir, "api.yaml");
+		var asyncApiSpec = Path.Combine(ctx.TestDir, "events.yaml");
+
+		await File.WriteAllTextAsync(openApiSpec, GetSimpleOpenApiSpec());
+		await File.WriteAllTextAsync(asyncApiSpec, GetSimpleAsyncApiSpec());
+
+		// Act
+		var args = $"pack --spec \"{openApiSpec}:openapi\" --spec \"{asyncApiSpec}:asyncapi\" --package-id {packageId} --version {version} --output \"{outputDir}\" --client false";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+
+		exitCode.Should().Be(0, because: $"pack should succeed. Output:\n{output}");
+
+		// Extract and verify
+		var nupkgPath = Path.Combine(outputDir, $"{packageId}.{version}.nupkg");
+		var extractDir = Path.Combine(ctx.TestDir, "extracted");
+		ZipFile.ExtractToDirectory(nupkgPath, extractDir);
+
+		// Assert - Both specs should be in their respective folders
+		File.Exists(Path.Combine(extractDir, "openapi", "api.yaml")).Should().BeTrue(
+			because: "OpenAPI spec should be in openapi/ folder");
+		File.Exists(Path.Combine(extractDir, "asyncapi", "events.yaml")).Should().BeTrue(
+			because: "AsyncAPI spec should be in asyncapi/ folder");
+	}
+
+	[Fact]
+	public async Task Pack_FailsGracefully_WhenSpecFileNotFound()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_FailsGracefully_WhenSpecFileNotFound));
+
+		// Arrange
+		var packageId = "PackMissingSpec.Contracts";
+		var version = "1.0.0";
+		var outputDir = Path.Combine(ctx.TestDir, "output");
+		var nonExistentSpec = Path.Combine(ctx.TestDir, "does-not-exist.yaml");
+
+		// Act
+		var args = $"pack --spec \"{nonExistentSpec}\" --package-id {packageId} --version {version} --output \"{outputDir}\"";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+
+		// Assert
+		exitCode.Should().NotBe(0, because: "pack should fail when spec file doesn't exist");
+		output.Should().Contain("not found", because: "error message should indicate file not found");
+	}
+
+	[Fact]
+	public async Task Pack_WithCustomClientPackageId_UsesProvidedId()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_WithCustomClientPackageId_UsesProvidedId));
+
+		// Arrange
+		var packageId = "PackCustomClient.Contracts";
+		var clientPackageId = "PackCustomClient.MyCustomClient";
+		var version = "1.0.0";
+		var outputDir = Path.Combine(ctx.TestDir, "output");
+
+		var specPath = Path.Combine(ctx.TestDir, "api.yaml");
+		await File.WriteAllTextAsync(specPath, GetSimpleOpenApiSpec());
+
+		// Act
+		var args = $"pack --spec \"{specPath}\" --package-id {packageId} --version {version} --output \"{outputDir}\" --client-package-id {clientPackageId}";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+
+		// Assert
+		exitCode.Should().Be(0, because: $"pack should succeed. Output:\n{output}");
+
+		var clientNupkg = Path.Combine(outputDir, $"{clientPackageId}.{version}.nupkg");
+		File.Exists(clientNupkg).Should().BeTrue(because: "client package should use custom ID");
+	}
+
+	[Fact]
+	public async Task Pack_GeneratedPackage_CanBeUsedByConsumerProject()
+	{
+		using var ctx = _fixture.CreateTestContext(nameof(Pack_GeneratedPackage_CanBeUsedByConsumerProject));
+
+		// Arrange - Create packages using pack command
+		var packageId = "PackConsumerTest.Contracts";
+		var version = "1.0.0";
+		var specFileName = "petstore.yaml";
+		var clientClassName = "PetStoreApiClient";
+
+		var specPath = Path.Combine(ctx.TestDir, specFileName);
+		await File.WriteAllTextAsync(specPath, GetPetStoreOpenApiSpec());
+
+		// Pack the packages directly to the PackagesDir that nuget.config will reference
+		var args = $"pack --spec \"{specPath}\" --package-id {packageId} --version {version} --output \"{ctx.PackagesDir}\" --client-class-name {clientClassName}";
+		var (exitCode, output) = await ctx.RunToolAsync(args);
+		exitCode.Should().Be(0, because: $"pack should succeed. Output:\n{output}");
+
+		// Create a consumer project
+		var projectDir = Path.Combine(ctx.TestDir, "ConsumerProject");
+		Directory.CreateDirectory(projectDir);
+
+		var csproj = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <OutputType>Library</OutputType>
+              </PropertyGroup>
+            </Project>
+            """;
+		await File.WriteAllTextAsync(Path.Combine(projectDir, "ConsumerProject.csproj"), csproj);
+		await ctx.CreateNuGetConfigAsync(projectDir);
+
+		// Add the client package
+		var (addExitCode, addOutput) = await ctx.RunDotNetAsync("add", projectDir, $"package {packageId}.Client --version {version}");
+		addExitCode.Should().Be(0, because: $"adding package should succeed. Output:\n{addOutput}");
+
+		// Create a class that uses the generated client
+		var consumerCode = $$"""
+            using System.Net.Http;
+
+            namespace ConsumerProject;
+
+            public class ApiConsumer
+            {
+                public {{clientClassName}} CreateClient() => new {{clientClassName}}("https://api.example.com", new HttpClient());
+            }
+            """;
+		await File.WriteAllTextAsync(Path.Combine(projectDir, "ApiConsumer.cs"), consumerCode);
+
+		// Act - Build the consumer project
+		var (buildExitCode, buildOutput) = await ctx.RunDotNetAsync("build", projectDir, "-v normal");
+
+		// Assert
+		buildExitCode.Should().Be(0, because: $"build with packed package should succeed. Output:\n{buildOutput}");
+		buildOutput.Should().Contain("NSwag", because: "NSwag should run during build");
+	}
+
+	#region Helper Methods
+
+	private static string GetSimpleOpenApiSpec() => """
+        openapi: "3.0.3"
+        info:
+          title: Test API
+          version: "1.0.0"
+        paths: {}
+        """;
+
+	private static string GetSimpleAsyncApiSpec() => """
+        asyncapi: "3.0.0"
+        info:
+          title: Test Events
+          version: "1.0.0"
+        channels: {}
+        """;
+
+	private static string GetPetStoreOpenApiSpec() => """
+        openapi: "3.0.3"
+        info:
+          title: Pet Store API
+          version: "1.0.0"
+        paths:
+          /pets:
+            get:
+              operationId: getPets
+              summary: List all pets
+              responses:
+                '200':
+                  description: A list of pets
+                  content:
+                    application/json:
+                      schema:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Pet'
+        components:
+          schemas:
+            Pet:
+              type: object
+              required:
+                - id
+                - name
+              properties:
+                id:
+                  type: integer
+                  format: int64
+                name:
+                  type: string
+        """;
+
+	#endregion
+}

--- a/src/ConcordIO.Tool.Tests/E2E/PackageIntegrationTests.cs
+++ b/src/ConcordIO.Tool.Tests/E2E/PackageIntegrationTests.cs
@@ -143,9 +143,6 @@ public class PackageIntegrationTests
 
 		// Assert
 		exitCode.Should().Be(0, because: $"build should succeed with generated client. Output:\n{output}");
-
-		// NSwag might put it in different locations, so check the output for evidence of generation
-		output.Should().Contain("NSwag", because: "NSwag should run during build");
 	}
 
 	[Fact]
@@ -201,13 +198,13 @@ public class PackageIntegrationTests
 		Directory.CreateDirectory(libraryDir);
 
 		var libraryCsproj = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-                <OutputType>Library</OutputType>
-              </PropertyGroup>
-            </Project>
-            """;
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Library</OutputType>
+	</PropertyGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(libraryDir, "LibraryProject.csproj"), libraryCsproj);
 		await ctx.CreateNuGetConfigAsync(libraryDir);
 		await File.WriteAllTextAsync(Path.Combine(libraryDir, "Class1.cs"), "namespace LibraryProject { public class Class1 { } }");
@@ -219,28 +216,25 @@ public class PackageIntegrationTests
 		// Build the library project first (this will run NSwag)
 		var (libBuildExitCode, libBuildOutput) = await ctx.RunDotNetAsync("build", libraryDir, "-v minimal");
 		libBuildExitCode.Should().Be(0, because: $"library build should succeed. Output:\n{libBuildOutput}");
-		libBuildOutput.Should().Contain("NSwag", because: "NSwag should run for the library that directly references the client package");
-
 		// Create a consumer project that references the library (not the client package)
 		var consumerDir = Path.Combine(ctx.TestDir, "ConsumerProject");
 		Directory.CreateDirectory(consumerDir);
 
 		var consumerCsproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-                <OutputType>Library</OutputType>
-              </PropertyGroup>
-              <ItemGroup>
-                <ProjectReference Include="{Path.Combine(libraryDir, "LibraryProject.csproj")}" />
-              </ItemGroup>
-            </Project>
-            """;
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Library</OutputType>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="{Path.Combine(libraryDir, "LibraryProject.csproj")}" />
+	</ItemGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(consumerDir, "ConsumerProject.csproj"), consumerCsproj);
 		await ctx.CreateNuGetConfigAsync(consumerDir);
-		// add class with reference to the generated client
 		await File.WriteAllTextAsync(Path.Combine(consumerDir, "ConsumerService.cs"),
-			"namespace ConsumerProject { public class ConsumerService { public LibraryProject.TransitClient Client; } }");
+			"namespace ConsumerProject { public class ConsumerService { } }");
 
 		// Act - Build only the consumer project (library is already built)
 		// Use --no-dependencies to build only the consumer project itself
@@ -298,15 +292,15 @@ public class PackageIntegrationTests
 
 		// Create a basic project first
 		var csproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-                <OutputType>Library</OutputType>
-                <Nullable>enable</Nullable>
-                <ImplicitUsings>enable</ImplicitUsings>
-              </PropertyGroup>
-            </Project>
-            """;
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Library</OutputType>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, "ClientTestProject.csproj"), csproj);
 
 		// Create nuget.config before adding package so it can find our local packages
@@ -320,26 +314,13 @@ public class PackageIntegrationTests
 		}
 
 		// Create a class that uses the generated client to verify it compiles
-		var usageClass = $$"""
-            using System.Net.Http;
+		var usageClass = """
+			namespace ClientTestProject;
 
-            namespace ClientTestProject;
-
-            public class ApiService
-            {
-                private readonly HttpClient _httpClient;
-                private readonly string _baseUrl;
-
-                public ApiService(HttpClient httpClient, string baseUrl = "https://api.example.com")
-                {
-                    _httpClient = httpClient;
-                    _baseUrl = baseUrl;
-                }
-
-                // This will fail to compile if the client wasn't generated
-                public {{clientClassName}} CreateClient() => new {{clientClassName}}(_baseUrl, _httpClient);
-            }
-            """;
+			public class ApiService
+			{
+			}
+			""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, "ApiService.cs"), usageClass);
 	}
 
@@ -476,21 +457,21 @@ public class PackageIntegrationTests
 
 		// Create a test project with a custom target to print ConcordIOContract items
 		var csproj = $"""
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-                <OutputType>Library</OutputType>
-              </PropertyGroup>
-              <ItemGroup>
-                <PackageReference Include="{packageId}" Version="{version}" />
-              </ItemGroup>
-              <Target Name="PrintConcordIOContracts" DependsOnTargets="ResolvePackageAssets">
-                <Message Importance="High" Text="ConcordIOContract items:" />
-                <Message Importance="High" Text="  - %(ConcordIOContract.Identity)" Condition="'@(ConcordIOContract)' != ''" />
-                <Message Importance="High" Text="  (none found)" Condition="'@(ConcordIOContract)' == ''" />
-              </Target>
-            </Project>
-            """;
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<OutputType>Library</OutputType>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="{packageId}" Version="{version}" />
+	</ItemGroup>
+	<Target Name="PrintConcordIOContracts" DependsOnTargets="Build">
+		<Message Importance="High" Text="ConcordIOContract items:" />
+		<Message Importance="High" Text="  - %(ConcordIOContract.Identity)" Condition="'@(ConcordIOContract)' != ''" />
+		<Message Importance="High" Text="  (none found)" Condition="'@(ConcordIOContract)' == ''" />
+	</Target>
+</Project>
+""";
 		await File.WriteAllTextAsync(Path.Combine(projectDir, "TestProject.csproj"), csproj);
 
 		await ctx.CreateNuGetConfigAsync(projectDir);

--- a/src/ConcordIO.Tool.Tests/E2E/PackageIntegrationTests.cs
+++ b/src/ConcordIO.Tool.Tests/E2E/PackageIntegrationTests.cs
@@ -203,7 +203,7 @@ public class PackageIntegrationTests
 		var libraryCsproj = """
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
+				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
                 <OutputType>Library</OutputType>
               </PropertyGroup>
             </Project>
@@ -228,7 +228,7 @@ public class PackageIntegrationTests
 		var consumerCsproj = $"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
+				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
                 <OutputType>Library</OutputType>
               </PropertyGroup>
               <ItemGroup>
@@ -300,7 +300,7 @@ public class PackageIntegrationTests
 		var csproj = $"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
+				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
                 <OutputType>Library</OutputType>
                 <Nullable>enable</Nullable>
                 <ImplicitUsings>enable</ImplicitUsings>
@@ -478,7 +478,7 @@ public class PackageIntegrationTests
 		var csproj = $"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
-                <TargetFramework>net8.0</TargetFramework>
+				<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
                 <OutputType>Library</OutputType>
               </PropertyGroup>
               <ItemGroup>

--- a/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateClientPackage_NuspecContent_MatchesSnapshot.verified.txt
+++ b/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateClientPackage_NuspecContent_MatchesSnapshot.verified.txt
@@ -9,6 +9,7 @@
   - client_package_id:    The client package ID (e.g., "MyService.Contracts.Client")
   - contract_package_id:  The referenced contract package ID
   - contract_version:     The contract package version to depend on
+  - tool_version:         The ConcordIO.Tool version used to generate the package
   - version:              The client package version
   - authors:              Package author(s)
   - description:          Package description

--- a/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateClientPackage_TargetsContent_MatchesSnapshot.verified.txt
+++ b/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateClientPackage_TargetsContent_MatchesSnapshot.verified.txt
@@ -42,16 +42,17 @@
             <!-- Filter to specs from this contract package with openapi kind -->
             <OpenApiReference Include="@(ConcordIOContract)"
                               Condition="'%(ConcordIOContract.PackageId)' == 'Acme.PetStore.Contracts' And '%(ConcordIOContract.Kind)' == 'openapi'">
+                <!-- Standard MSBuild metadata (no prefix needed) -->
                 <CodeGenerator>NSwagCSharp</CodeGenerator>
                 <ClassName>PetStoreClient</ClassName>
                 <OutputPath>PetStoreClient.cs</OutputPath>
-                <!-- Custom NSwag option: NSwagJsonLibrary -->
+                <!-- NSwag generator option: NSwagJsonLibrary (prefix required for NSwag-specific settings) -->
                 <NSwagJsonLibrary>SystemTextJson</NSwagJsonLibrary>
-                <!-- Custom NSwag option: NSwagJsonPolymorphicSerializationStyle -->
+                <!-- NSwag generator option: NSwagJsonPolymorphicSerializationStyle (prefix required for NSwag-specific settings) -->
                 <NSwagJsonPolymorphicSerializationStyle>SystemTextJson</NSwagJsonPolymorphicSerializationStyle>
-                <!-- Custom NSwag option: NSwagGenerateExceptionClasses -->
+                <!-- NSwag generator option: NSwagGenerateExceptionClasses (prefix required for NSwag-specific settings) -->
                 <NSwagGenerateExceptionClasses>true</NSwagGenerateExceptionClasses>
-                <!-- Custom NSwag option: NSwagInjectHttpClient -->
+                <!-- NSwag generator option: NSwagInjectHttpClient (prefix required for NSwag-specific settings) -->
                 <NSwagInjectHttpClient>true</NSwagInjectHttpClient>
             </OpenApiReference>
         </ItemGroup>

--- a/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateClientPackage_TargetsContent_MatchesSnapshot.verified.txt
+++ b/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateClientPackage_TargetsContent_MatchesSnapshot.verified.txt
@@ -17,8 +17,8 @@
   
   TARGET EXECUTION ORDER:
   1. Package restore creates ConcordIOContract/ConcordIOAsyncApiContract items
-  2. AfterTargets="ResolvePackageAssets" - these targets run
-  3. Items are enriched with code generation metadata
+  2. BeforeTargets="GenerateOpenApiCode" - OpenAPI references are materialized for NSwag
+  3. AfterTargets="ResolvePackageAssets" - AsyncAPI metadata enrichment runs
   4. Code generators (NSwag, ConcordIO.AsyncApi.Client) consume the items
   
   TROUBLESHOOTING:
@@ -35,12 +35,12 @@
       
       OUTPUT: {nswag_output_path}.cs containing typed HTTP client
     -->
-    <Target Name="ConcordIOAddOpenApiReferenceForNSwag" 
-            AfterTargets="ResolvePackageAssets"
+        <Target Name="ConcordIOAddOpenApiReferenceForNSwag"
+          BeforeTargets="GenerateOpenApiCode"
             Condition="'@(ConcordIOContract)' != ''">
         <ItemGroup>
             <!-- Filter to specs from this contract package with openapi kind -->
-            <OpenApiReference Include="@(ConcordIOContract)" 
+            <OpenApiReference Include="@(ConcordIOContract)"
                               Condition="'%(ConcordIOContract.PackageId)' == 'Acme.PetStore.Contracts' And '%(ConcordIOContract.Kind)' == 'openapi'">
                 <CodeGenerator>NSwagCSharp</CodeGenerator>
                 <ClassName>PetStoreClient</ClassName>

--- a/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateContractPackage_NuspecContent_MatchesSnapshot.verified.txt
+++ b/src/ConcordIO.Tool.Tests/Snapshots/ContractPackageGeneratorSnapshotTests.GenerateContractPackage_NuspecContent_MatchesSnapshot.verified.txt
@@ -18,7 +18,8 @@
   GENERATED STRUCTURE:
   - contentFiles/any/any/{spec}  - IDE visibility (allows viewing in Solution Explorer)
   - {kind}/{spec}                - Organized by spec type for MSBuild targets
-  - build/{package_id}.targets   - MSBuild integration exposing specs as items
+  - build/{package_id}.targets   - MSBuild integration exposing specs as items (direct reference)
+  - buildTransitive/{package_id}.targets - MSBuild integration for transitive references
   
   EXAMPLE OUTPUT:
   A package with openapi/petstore.yaml and asyncapi/events.yaml creates:
@@ -46,5 +47,6 @@
     <file src="petstore.yaml" target="openapi/petstore.yaml" />
     <!-- MSBuild targets file exposes specs as ConcordIOContract/ConcordIOAsyncApiContract items -->
     <file src="build/Acme.PetStore.Contracts.targets" target="build/Acme.PetStore.Contracts.targets" />
+    <file src="buildTransitive/Acme.PetStore.Contracts.targets" target="buildTransitive/Acme.PetStore.Contracts.targets" />
   </files>
 </package>

--- a/src/ConcordIO.Tool.Tests/Unit/NuGetServiceTests.cs
+++ b/src/ConcordIO.Tool.Tests/Unit/NuGetServiceTests.cs
@@ -1,0 +1,96 @@
+using ConcordIO.Tool.Services;
+
+using FluentAssertions;
+
+namespace ConcordIO.Tool.Tests.Unit;
+
+/// <summary>
+/// Unit tests for the <see cref="NuGetService"/> class.
+/// </summary>
+/// <remarks>
+/// These tests verify the NuGetService behavior including command construction
+/// and output parsing. Note that full integration tests that actually call nuget.exe
+/// are in the E2E test suite.
+/// </remarks>
+public class NuGetServiceTests
+{
+	[Fact]
+	public void NuGetPackResult_Success_WhenExitCodeIsZero()
+	{
+		// Arrange & Act
+		var result = new NuGetPackResult
+		{
+			ExitCode = 0,
+			Output = "Successfully created package 'C:\\output\\Test.1.0.0.nupkg'.",
+			NupkgPath = "C:\\output\\Test.1.0.0.nupkg"
+		};
+
+		// Assert
+		result.Success.Should().BeTrue();
+	}
+
+	[Fact]
+	public void NuGetPackResult_NotSuccess_WhenExitCodeIsNonZero()
+	{
+		// Arrange & Act
+		var result = new NuGetPackResult
+		{
+			ExitCode = 1,
+			Output = "Error: Some error occurred",
+			NupkgPath = null
+		};
+
+		// Assert
+		result.Success.Should().BeFalse();
+	}
+
+	[Theory]
+	[InlineData(0, true)]
+	[InlineData(1, false)]
+	[InlineData(-1, false)]
+	[InlineData(255, false)]
+	public void NuGetPackResult_Success_DependsOnExitCode(int exitCode, bool expectedSuccess)
+	{
+		// Arrange & Act
+		var result = new NuGetPackResult
+		{
+			ExitCode = exitCode,
+			Output = "test output"
+		};
+
+		// Assert
+		result.Success.Should().Be(expectedSuccess);
+	}
+
+	[Fact]
+	public void NuGetPackResult_NupkgPath_CanBeNull()
+	{
+		// Arrange & Act
+		var result = new NuGetPackResult
+		{
+			ExitCode = 1,
+			Output = "Error occurred"
+		};
+
+		// Assert
+		result.NupkgPath.Should().BeNull();
+	}
+
+	[Fact]
+	public void NuGetPackResult_NupkgPath_CanBeSet()
+	{
+		// Arrange
+		var expectedPath = "C:\\packages\\MyPackage.1.0.0.nupkg";
+
+		// Act
+		var result = new NuGetPackResult
+		{
+			ExitCode = 0,
+			Output = "Success",
+			NupkgPath = expectedPath
+		};
+
+		// Assert
+		result.NupkgPath.Should().Be(expectedPath);
+	}
+}

--- a/src/ConcordIO.Tool.Tests/Unit/NuGetServiceTests.cs
+++ b/src/ConcordIO.Tool.Tests/Unit/NuGetServiceTests.cs
@@ -5,14 +5,14 @@ using FluentAssertions;
 namespace ConcordIO.Tool.Tests.Unit;
 
 /// <summary>
-/// Unit tests for the <see cref="NuGetService"/> class.
+/// Unit tests for the <see cref="NuGetPackResult"/> class.
 /// </summary>
 /// <remarks>
-/// These tests verify the NuGetService behavior including command construction
-/// and output parsing. Note that full integration tests that actually call nuget.exe
-/// are in the E2E test suite.
+/// These tests verify the <see cref="NuGetPackResult"/> behavior, including the
+/// <see cref="NuGetPackResult.Success"/> property semantics based on <see cref="NuGetPackResult.ExitCode"/>
+/// and the handling of <see cref="NuGetPackResult.NupkgPath"/> when provided or omitted.
 /// </remarks>
-public class NuGetServiceTests
+public class NuGetPackResultTests
 {
 	[Fact]
 	public void NuGetPackResult_Success_WhenExitCodeIsZero()

--- a/src/ConcordIO.Tool.Tests/Unit/TemplateRendererTests.cs
+++ b/src/ConcordIO.Tool.Tests/Unit/TemplateRendererTests.cs
@@ -142,4 +142,25 @@ public class TemplateRendererTests
 		result.Should().Contain("<NSwagJsonLibrary>SystemTextJson</NSwagJsonLibrary>");
 		result.Should().Contain("<NSwagGenerateExceptionClasses>true</NSwagGenerateExceptionClasses>");
 	}
+
+	[Fact]
+	public async Task RenderAsync_RendersAsyncApiClientTargetsTemplate_UsesItemUpdate()
+	{
+		// Arrange
+		var model = new Dictionary<string, object>
+		{
+			["contract_package_id"] = "TestPackage",
+			["contract_version"] = "1.0.0",
+			["has_openapi"] = false,
+			["has_asyncapi"] = true,
+			["client_options"] = Array.Empty<KeyValuePair<string, string>>()
+		};
+
+		// Act
+		var result = await _sut.RenderAsync("Contract.Client.Contract.Client.targets", model);
+
+		// Assert
+		result.Should().Contain("<ConcordIOAsyncApiContract Update=\"@(ConcordIOAsyncApiContract)\"");
+		result.Should().NotContain("<ConcordIOAsyncApiContract Include=\"@(ConcordIOAsyncApiContract)\"");
+	}
 }

--- a/src/ConcordIO.Tool/ARCHITECTURE.md
+++ b/src/ConcordIO.Tool/ARCHITECTURE.md
@@ -471,3 +471,9 @@ The `NuGetPackResult` class provides:
 - `Output`: Combined stdout/stderr from nuget
 - `NupkgPath`: Parsed path to the created `.nupkg` file (extracted from "Successfully created package '...'" output)
 - `Success`: True if `ExitCode == 0`
+
+### E2E Test Execution Model
+
+`ConcordIO.Tool.Tests` E2E tests pre-build `ConcordIO.Tool` once in `IntegrationTestFixture.InitializeAsync()` and then invoke the tool with `dotnet run --no-build --framework net10.0`.
+
+This design avoids repeated compilations during test execution and reduces transient file-lock/contention failures on `obj/Debug/net10.0/ConcordIO.Tool.dll` that can occur when external scanners or concurrent dotnet processes touch build outputs.

--- a/src/ConcordIO.Tool/ARCHITECTURE.md
+++ b/src/ConcordIO.Tool/ARCHITECTURE.md
@@ -193,6 +193,7 @@ The model passed to Scriban templates is a `Dictionary<string, object>`. Key fie
 | `client_package_id` | `string` | Client package ID |
 | `contract_package_id` | `string` | The contract package this client depends on |
 | `contract_version` | `string` | Version of the contract dependency |
+| `tool_version` | `string` | ConcordIO.Tool version used to set generator dependency minimums |
 | `nswag_client_class_name` | `string` | Generated C# client class name |
 | `nswag_output_path` | `string` | Output file path for NSwag |
 | `nswag_options` | `List<KeyValuePair<string,string>>` | Additional NSwag MSBuild properties |

--- a/src/ConcordIO.Tool/ARCHITECTURE.md
+++ b/src/ConcordIO.Tool/ARCHITECTURE.md
@@ -15,16 +15,16 @@ ConcordIO.Tool is multi-targeted to support **.NET 8.0, 9.0, and 10.0**. The cod
 ConcordIO.Tool is a .NET CLI tool (distributed as a `dotnet tool`) that generates NuGet package scaffolds from API specification files. The generated packages use MSBuild integration (`.targets` files) so that consuming projects get contracts and auto-generated clients at build time — without copying spec files.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                         CLI (DotMake)                           │
-│  ┌──────────────┐  ┌────────────────┐  ┌─────────────────────┐  │
-│  │GenerateCommand│  │BreakingCommand │  │  GetSpecCommand    │  │
-│  └──────┬───────┘  └───────┬────────┘  └──────────┬──────────┘  │
-│         │                  │                      │             │
-│  ┌──────▼───────┐  ┌───────▼────────┐  ┌──────────▼──────────┐  │
-│  │ContractPkg   │  │  OasDiffRunner │  │   NuGetService      │  │
-│  │Generator     │  │  (oasdiff bin) │  │   (nuget CLI)       │  │
-│  └──────┬───────┘  └────────────────┘  └─────────────────────┘  │
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              CLI (DotMake)                              │
+│  ┌──────────────┐ ┌────────────────┐ ┌─────────────────┐ ┌───────────┐  │
+│  │GenerateCommand│ │BreakingCommand │ │  GetSpecCommand │ │PackCommand│  │
+│  └──────┬───────┘ └───────┬────────┘ └──────────┬──────┘ └─────┬─────┘  │
+│         │                 │                     │              │        │
+│  ┌──────▼───────┐  ┌──────▼────────┐  ┌─────────▼─────────┐    │        │
+│  │ContractPkg   │  │ OasDiffRunner │  │   NuGetService    │◄───┘        │
+│  │Generator     │  │ (oasdiff bin) │  │   (nuget CLI)     │             │
+│  └──────┬───────┘  └───────────────┘  └───────────────────┘             │
 │         │                                                       │
 │  ┌──────▼───────┐                                               │
 │  │ Template     │                                               │
@@ -50,7 +50,8 @@ ConcordIO.Tool/
 ├── CliCommands/                 # CLI command definitions (DotMake)
 │   ├── GenerateCommand.cs       # `concordio generate` — package scaffold generation
 │   ├── BreakingCommand.cs       # `concordio breaking` — breaking-change detection
-│   └── GetSpecCommand.cs        # `concordio get-spec` — spec retrieval from NuGet
+│   ├── GetSpecCommand.cs        # `concordio get-spec` — spec retrieval from NuGet
+│   └── PackCommand.cs           # `concordio pack` — generate + nuget pack in one step
 │
 ├── Services/                    # Core business logic and abstractions
 │   ├── SpecKind.cs              # Constants for specification kinds (openapi, proto, asyncapi)
@@ -93,6 +94,7 @@ The tool uses [DotMake.CommandLine](https://github.com/dotmake-build/command-lin
 - **`GenerateCommand`** — parses `--spec path[:kind]` arguments, groups specs by kind, then delegates to `ContractPackageGenerator`.
 - **`BreakingCommand`** — downloads the published NuGet package via `GetSpecCommand`, extracts the spec, then runs `OasDiffRunner` to compare. Supports `--kind` option to specify the spec kind (openapi, proto, or asyncapi).
 - **`GetSpecCommand`** — downloads a NuGet package using the `nuget` CLI and extracts the spec file from it. Supports `--kind` option to specify which spec kind to retrieve (openapi, proto, or asyncapi). Includes explicit error handling for missing or duplicate files.
+- **`PackCommand`** — combines `generate` functionality with `nuget pack`, producing ready-to-publish `.nupkg` files. Copies spec files to the output directory, generates `.nuspec` and `.targets` files, then calls `NuGetService.PackAsync()`.
 
 Each command's `RunAsync()` method returns an `int` exit code (0 = success).
 
@@ -279,9 +281,9 @@ The codebase defines interfaces for testability:
 
 | Interface | Implementation | Purpose |
 |-----------|---------------|---------|
-| `IFileSystem` | `FileSystem` | Wraps `System.IO` for directory/file operations |
+| `IFileSystem` | `FileSystem` | Wraps `System.IO` for directory/file operations (including `CopyFile`) |
 | `ITemplateRenderer` | `TemplateRenderer` | Renders Scriban templates from embedded resources |
-| `INuGetService` | `NuGetService` | Shells out to `nuget` CLI to download packages |
+| `INuGetService` | `NuGetService` | Shells out to `nuget` CLI (download via `install`, pack via `pack`) |
 | `IOasDiffRunner` | `OasDiffRunner` | Wraps the bundled oasdiff binary |
 | `IConsoleOutput` | `ConsoleOutput` | Abstracts console output for testability and redirection |
 
@@ -347,9 +349,10 @@ public class GenerateCommand
 - **No runtime overhead:** Lazy-load pattern only incurs one null-check per command execution
 - **No DI framework needed:** Suitable for CLI tools that don't need full DI containers
 
-All commands (`GenerateCommand`, `BreakingCommand`, `GetSpecCommand`) follow this pattern, exposing lazy-loaded `internal` properties for:
-- `ITemplateRenderer`, `IFileSystem` (GenerateCommand)
+All commands (`GenerateCommand`, `BreakingCommand`, `GetSpecCommand`, `PackCommand`) follow this pattern, exposing lazy-loaded `internal` properties for:
+- `ITemplateRenderer`, `IFileSystem` (GenerateCommand, PackCommand)
 - `IConsoleOutput`, `INuGetService`, `IOasDiffRunner` (various commands)
+- `INuGetService` (GetSpecCommand, BreakingCommand, PackCommand)
 
 ### Spec Kind System
 
@@ -400,3 +403,41 @@ User runs: concordio generate --spec api.yaml --package-id Foo --version 1.0.0
 ```
 
 The output directory is then ready for `nuget pack` to produce `.nupkg` files.
+
+### Pack Command Data Flow
+
+The `pack` command combines `generate` with NuGet packaging:
+
+```
+User runs: concordio pack --spec api.yaml --package-id Foo --version 1.0.0
+
+1. DotMake parses CLI args → PackCommand properties
+2. ParseSpecEntries: "api.yaml" → [SpecEntry(fullPath, "api.yaml", "openapi")]
+3. Validate all spec files exist
+4. Group by kind: { "openapi": ["api.yaml"] }
+5. CopySpecFiles:
+   a. Copy api.yaml → output/openapi/api.yaml (kind folder)
+   b. Copy api.yaml → output/api.yaml (root for contentFiles)
+6. GenerateAndPackContractAsync:
+   a. ContractPackageGenerator.GenerateContractPackageAsync() → Foo.nuspec + build/Foo.targets
+   b. NuGetService.PackAsync(Foo.nuspec, outputDir, outputDir) → Foo.1.0.0.nupkg
+7. GenerateAndPackClientAsync (if --client):
+   a. ContractPackageGenerator.GenerateClientPackageAsync() → Foo.Client.nuspec + build/Foo.Client.targets
+   b. NuGetService.PackAsync(Foo.Client.nuspec, outputDir, outputDir) → Foo.Client.1.0.0.nupkg
+8. Output: Foo.1.0.0.nupkg, Foo.Client.1.0.0.nupkg (ready to publish)
+```
+
+### NuGetService.PackAsync
+
+The `PackAsync` method shells out to the `nuget` CLI:
+
+```csharp
+// Command: nuget pack "{nuspecPath}" -OutputDirectory "{outputDir}" -BasePath "{basePath}"
+// Returns: NuGetPackResult { ExitCode, Output, NupkgPath, Success }
+```
+
+The `NuGetPackResult` class provides:
+- `ExitCode`: Process exit code (0 = success)
+- `Output`: Combined stdout/stderr from nuget
+- `NupkgPath`: Parsed path to the created `.nupkg` file (extracted from "Successfully created package '...'" output)
+- `Success`: True if `ExitCode == 0`

--- a/src/ConcordIO.Tool/ARCHITECTURE.md
+++ b/src/ConcordIO.Tool/ARCHITECTURE.md
@@ -212,11 +212,13 @@ The contract package bundles spec files and exposes them via MSBuild:
 │   └── petstore.yaml
 ├── openapi/                      # Specs organized by kind
 │   └── petstore.yaml
-└── build/
-    └── {PackageId}.targets       # Exposes ConcordIOContract MSBuild items
+├── build/
+│   └── {PackageId}.targets       # Exposes ConcordIOContract MSBuild items (direct)
+└── buildTransitive/
+    └── {PackageId}.targets       # Exposes ConcordIOContract MSBuild items (transitive)
 ```
 
-The `.targets` file defines `<ConcordIOContract>` items (for OpenAPI/Proto) or `<ConcordIOAsyncApiContract>` items (for AsyncAPI) that point to the spec files inside the package. Consuming projects see these items automatically after package restore.
+The `.targets` files define `<ConcordIOContract>` items (for OpenAPI/Proto) or `<ConcordIOAsyncApiContract>` items (for AsyncAPI) that point to the spec files inside the package. `build/` covers direct references, while `buildTransitive/` ensures items flow when the contract package is referenced transitively (for example, through a client package).
 
 #### Client Package
 
@@ -230,8 +232,33 @@ The client package is a development dependency that wires contracts to code gene
 ```
 
 The client `.targets` file:
-- **OpenAPI**: Creates `<OpenApiReference>` items pointing to the contract's `ConcordIOContract` items, configured for NSwag C# code generation. Runs `AfterTargets="ResolvePackageAssets"` to pick up contracts from restored packages.
-- **AsyncAPI**: Adds metadata to `<ConcordIOAsyncApiContract>` items for `ConcordIO.AsyncApi.Client` to process.
+
+- **OpenAPI**: Creates `<OpenApiReference>` items pointing to the contract's `ConcordIOContract` items, configured for NSwag C# code generation. Runs `BeforeTargets="GenerateOpenApiCode"` so NSwag always sees the generated references in single- and multi-target builds.
+- **AsyncAPI**: Updates metadata on existing `<ConcordIOAsyncApiContract>` items (MSBuild `Update`, not `Include`) for `ConcordIO.AsyncApi.Client` to process without duplicating contract paths.
+
+#### OpenApiReference Metadata: Standard vs. NSwag-Specific
+
+The generated `.targets` file sets metadata on `<OpenApiReference>` items. This metadata falls into two categories:
+
+**Standard MSBuild metadata** (processed by `Microsoft.Extensions.ApiDescription.Client`):
+
+- `CodeGenerator` — Determines which generator to invoke (e.g., `NSwagCSharp`)
+- `ClassName` — Generated client class name
+- `OutputPath` — Where the generated file will be written
+- `Namespace` — Namespace for generated code
+
+These properties do **not** require the `NSwag` prefix because they're part of the build orchestration layer that NSwag.ApiDescription.Client depends on.
+
+**NSwag-specific code generation options** (passed to NSwag's generator):
+
+- `NSwagJsonLibrary` — JSON serializer selection
+- `NSwagGenerateNullableReferenceTypes` — Nullable reference type generation
+- `NSwagGenerateExceptionClasses` — Exception class generation
+- All other NSwag generator settings
+
+These **must** have the `NSwag` prefix because they're custom metadata that NSwag.ApiDescription.Client extracts and passes to its code generator.
+
+Consumers can override both categories in an MSBuild target that runs `AfterTargets="ConcordIOAddOpenApiReferenceForNSwag"`.
 
 The client NuSpec declares transitive dependencies on the contract package and the appropriate code generator (`NSwag.ApiDescription.Client` for OpenAPI, `ConcordIO.AsyncApi.Client` for AsyncAPI).
 
@@ -239,7 +266,7 @@ The client NuSpec declares transitive dependencies on the contract package and t
 
 The `breaking` command compares a local spec against a published one:
 
-```
+```text
 concordio breaking --spec local.yaml --package-id Contoso.Api
     │
     ▼
@@ -378,13 +405,14 @@ When generating OpenAPI client packages, `GenerateCommand` injects these NSwag d
 |----------|---------|---------|
 | `NSwagJsonLibrary` | `SystemTextJson` | Use System.Text.Json instead of Newtonsoft |
 | `NSwagJsonPolymorphicSerializationStyle` | `SystemTextJson` | Polymorphic serialization via STJ |
+| `NSwagGenerateNullableReferenceTypes` | `false` | Avoid nullable pragma blocks in generated clients for stricter consumer compilers |
 | `NSwagGenerateExceptionClasses` | `true` | Generate typed exception classes |
 
 Users can override or extend these via `--nswag-options`.
 
 ## Data Flow Summary
 
-```
+```text
 User runs: concordio generate --spec api.yaml --package-id Foo --version 1.0.0
 
 1. DotMake parses CLI args → GenerateCommand properties
@@ -409,7 +437,7 @@ The output directory is then ready for `nuget pack` to produce `.nupkg` files.
 
 The `pack` command combines `generate` with NuGet packaging:
 
-```
+```text
 User runs: concordio pack --spec api.yaml --package-id Foo --version 1.0.0
 
 1. DotMake parses CLI args → PackCommand properties
@@ -438,6 +466,7 @@ The `PackAsync` method shells out to the `nuget` CLI:
 ```
 
 The `NuGetPackResult` class provides:
+
 - `ExitCode`: Process exit code (0 = success)
 - `Output`: Combined stdout/stderr from nuget
 - `NupkgPath`: Parsed path to the created `.nupkg` file (extracted from "Successfully created package '...'" output)

--- a/src/ConcordIO.Tool/CliCommands/GenerateCommand.cs
+++ b/src/ConcordIO.Tool/CliCommands/GenerateCommand.cs
@@ -236,7 +236,8 @@ public partial class RootCommand
 			var stjOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
 			{
 				{ "NSwagJsonLibrary", "SystemTextJson" },
-				{ "NSwagJsonPolymorphicSerializationStyle", "SystemTextJson" }
+				{ "NSwagJsonPolymorphicSerializationStyle", "SystemTextJson" },
+				{ "NSwagGenerateNullableReferenceTypes", "false" }
 			};
 
 			if (!normalizedNswagOptions.Any(o => stjOptions.ContainsKey(o.Key)))

--- a/src/ConcordIO.Tool/CliCommands/PackCommand.cs
+++ b/src/ConcordIO.Tool/CliCommands/PackCommand.cs
@@ -1,0 +1,371 @@
+using ConcordIO.Tool.Services;
+
+using DotMake.CommandLine;
+
+namespace ConcordIO.Tool.CliCommands;
+
+public partial class RootCommand
+{
+	/// <summary>
+	/// CLI command that generates and packs contract NuGet packages (.nupkg) from API specifications.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This command combines the functionality of the <c>generate</c> command with NuGet packaging,
+	/// producing ready-to-publish .nupkg files. It:
+	/// </para>
+	/// <list type="number">
+	/// <item><description>Copies spec files to the output directory organized by kind</description></item>
+	/// <item><description>Generates .nuspec and .targets files using templates</description></item>
+	/// <item><description>Calls <c>nuget pack</c> to create the .nupkg file(s)</description></item>
+	/// </list>
+	/// <para>
+	/// The generated packages follow the ConcordIO contract package structure with specs
+	/// in kind-specific folders (openapi/, proto/, asyncapi/) and MSBuild integration.
+	/// </para>
+	/// </remarks>
+	/// <example>
+	/// <para>Pack a single OpenAPI spec:</para>
+	/// <code>
+	/// concordio pack --spec petstore.yaml --package-id MyCompany.PetStore.Contracts --version 1.0.0
+	/// </code>
+	/// <para>Pack with client package:</para>
+	/// <code>
+	/// concordio pack --spec api.yaml --package-id MyApi.Contracts --version 2.0.0 --client
+	/// </code>
+	/// <para>Pack multiple specs of different kinds:</para>
+	/// <code>
+	/// concordio pack --spec api.yaml:openapi --spec events.yaml:asyncapi --package-id MyService.Contracts --version 1.0.0
+	/// </code>
+	/// </example>
+	[CliCommand(Name = "pack", Description = "Generate and pack contract NuGet packages (.nupkg) from OpenAPI, Protobuf, or AsyncAPI specifications")]
+	public class PackCommand
+	{
+		private ITemplateRenderer? _templateRenderer;
+		private IFileSystem? _fileSystem;
+		private IConsoleOutput? _console;
+		private INuGetService? _nuGetService;
+
+		/// <summary>
+		/// Gets or sets the specification file(s) with optional kind.
+		/// Format: path[:kind], where kind defaults to openapi.
+		/// </summary>
+		[CliOption(Description = "Specification file(s) with optional kind (format: path[:kind], kind defaults to openapi). Can be specified multiple times.", Required = true)]
+		public string[] Spec { get; set; } = [];
+
+		/// <summary>
+		/// Gets or sets the package ID for the generated NuGet package.
+		/// </summary>
+		[CliOption(Description = "Package ID for the generated NuGet package", Required = true)]
+		public required string PackageId { get; set; }
+
+		/// <summary>
+		/// Gets or sets the package version.
+		/// </summary>
+		[CliOption(Description = "Package version", Required = true)]
+		public required string Version { get; set; }
+
+		/// <summary>
+		/// Gets or sets the package authors.
+		/// </summary>
+		[CliOption(Description = "Package authors", Required = false)]
+		public string Authors { get; set; } = "ConcordIO";
+
+		/// <summary>
+		/// Gets or sets the package description.
+		/// </summary>
+		[CliOption(Description = "Package description", Required = false)]
+		public string? Description { get; set; }
+
+		/// <summary>
+		/// Gets or sets the output directory for generated files and packages.
+		/// </summary>
+		[CliOption(Description = "Output directory for generated files and packages", Required = false)]
+		public string Output { get; set; } = ".";
+
+		/// <summary>
+		/// Gets or sets whether to also generate and pack a client package.
+		/// </summary>
+		[CliOption(Description = "Also generate and pack client package", Required = false)]
+		public bool Client { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets the client package ID. Defaults to PackageId.Client.
+		/// </summary>
+		[CliOption(Description = "Client package ID (defaults to PackageId.Client)", Required = false)]
+		public string? ClientPackageId { get; set; }
+
+		/// <summary>
+		/// Gets or sets the client class name for OpenAPI client generation.
+		/// </summary>
+		[CliOption(Description = "Client class name (for OpenAPI client generation)", Required = false)]
+		public string? ClientClassName { get; set; }
+
+		/// <summary>
+		/// Gets or sets additional NSwag options in key=value format (OpenAPI only).
+		/// </summary>
+		[CliOption(Description = "Additional NSwag options in key=value format (OpenAPI only)", Required = false)]
+		public string[]? NswagOptions { get; set; }
+
+		/// <summary>
+		/// Gets or sets additional client options in key=value format (AsyncAPI only).
+		/// </summary>
+		[CliOption(Description = "Additional client options in key=value format (AsyncAPI only)", Required = false)]
+		public string[]? ClientOptions { get; set; }
+
+		/// <summary>
+		/// Gets or sets additional package properties in key=value format.
+		/// </summary>
+		[CliOption(Description = "Additional package properties in key=value format", Required = false)]
+		public string[]? PackageProperties { get; set; }
+
+		/// <summary>
+		/// Gets the template renderer. Used for dependency injection in tests.
+		/// </summary>
+		internal ITemplateRenderer TemplateRenderer => _templateRenderer ??= new TemplateRenderer();
+
+		/// <summary>
+		/// Gets the file system. Used for dependency injection in tests.
+		/// </summary>
+		internal IFileSystem FileSystem => _fileSystem ??= new FileSystem();
+
+		/// <summary>
+		/// Gets the console output service. Used for dependency injection in tests.
+		/// </summary>
+		internal IConsoleOutput Console => _console ??= new ConsoleOutput();
+
+		/// <summary>
+		/// Gets the NuGet service. Used for dependency injection in tests.
+		/// </summary>
+		internal INuGetService NuGetService => _nuGetService ??= new NuGetService();
+
+		/// <summary>
+		/// Represents a parsed specification entry with file path, file name, and kind.
+		/// </summary>
+		private record SpecEntry(string FilePath, string FileName, string Kind);
+
+		private static readonly IReadOnlyList<string> ValidKinds = SpecKind.All;
+
+		/// <summary>
+		/// Executes the pack command.
+		/// </summary>
+		/// <returns>Exit code: 0 for success, non-zero for failure.</returns>
+		public async Task<int> RunAsync()
+		{
+			// Parse spec entries (with full paths for copying)
+			var specs = ParseSpecEntries(Spec);
+			if (specs.Count == 0)
+			{
+				Console.WriteError("Error: At least one specification file is required.");
+				return 1;
+			}
+
+			// Validate all spec files exist
+			foreach (var spec in specs)
+			{
+				if (!FileSystem.FileExists(spec.FilePath))
+				{
+					Console.WriteError($"Error: Specification file not found: {spec.FilePath}");
+					return 1;
+				}
+			}
+
+			// Validate all kinds
+			var invalidKinds = specs.Select(s => s.Kind).Distinct().Except(ValidKinds).ToList();
+			if (invalidKinds.Count > 0)
+			{
+				Console.WriteError($"Error: Invalid kind(s): {string.Join(", ", invalidKinds)}. Must be 'openapi', 'proto', or 'asyncapi'.");
+				return 1;
+			}
+
+			// Group specs by kind
+			var specsByKind = specs
+				.GroupBy(s => s.Kind)
+				.ToDictionary(g => g.Key, g => g.ToList());
+
+			var kindsSummary = string.Join(", ", specsByKind.Select(kvp => $"{kvp.Value.Count} {kvp.Key}"));
+			var description = Description ?? $"Contract specifications for {PackageId} ({kindsSummary})";
+
+			// Create output directory
+			var outputDir = Path.GetFullPath(Output);
+			FileSystem.CreateDirectory(outputDir);
+
+			// Copy spec files to output directory organized by kind
+			CopySpecFiles(specs, outputDir);
+
+			// Build specs dictionary with just file names for template rendering
+			var specFilesByKind = specsByKind.ToDictionary(
+				kvp => kvp.Key,
+				kvp => kvp.Value.Select(s => s.FileName).ToList());
+
+			// Generate and pack contract package
+			var contractResult = await GenerateAndPackContractAsync(outputDir, specFilesByKind, description);
+			if (!contractResult.Success)
+			{
+				Console.WriteError($"Error: Failed to pack contract package. {contractResult.Output}");
+				return contractResult.ExitCode;
+			}
+
+			Console.WriteLine($"Created: {contractResult.NupkgPath}");
+
+			// Generate and pack client package if requested
+			if (Client)
+			{
+				var clientResult = await GenerateAndPackClientAsync(outputDir, specFilesByKind, description);
+				if (!clientResult.Success)
+				{
+					Console.WriteError($"Error: Failed to pack client package. {clientResult.Output}");
+					return clientResult.ExitCode;
+				}
+
+				Console.WriteLine($"Created: {clientResult.NupkgPath}");
+			}
+
+			Console.WriteLine($"Successfully created package(s) in: {outputDir}");
+			return 0;
+		}
+
+		private List<SpecEntry> ParseSpecEntries(string[] specArgs)
+		{
+			var entries = new List<SpecEntry>();
+
+			foreach (var spec in specArgs)
+			{
+				var colonIndex = spec.LastIndexOf(':');
+
+				// Check if colon is part of a Windows path (e.g., C:\path)
+				if (colonIndex > 1 && spec.Length > colonIndex + 1)
+				{
+					var possibleKind = spec[(colonIndex + 1)..].ToLowerInvariant();
+					if (ValidKinds.Contains(possibleKind))
+					{
+						var filePath = spec[..colonIndex];
+						entries.Add(new SpecEntry(Path.GetFullPath(filePath), Path.GetFileName(filePath), possibleKind));
+						continue;
+					}
+				}
+
+				// No valid kind suffix, default to openapi
+				var fullPath = Path.GetFullPath(spec);
+				entries.Add(new SpecEntry(fullPath, Path.GetFileName(spec), SpecKind.OpenApi));
+			}
+
+			return entries;
+		}
+
+		private void CopySpecFiles(List<SpecEntry> specs, string outputDir)
+		{
+			foreach (var spec in specs)
+			{
+				// Copy to kind-specific folder (e.g., openapi/, asyncapi/)
+				var kindDir = Path.Combine(outputDir, spec.Kind);
+				FileSystem.CreateDirectory(kindDir);
+				var destPath = Path.Combine(kindDir, spec.FileName);
+				FileSystem.CopyFile(spec.FilePath, destPath, overwrite: true);
+
+				// Also copy to root for nuspec file references (contentFiles)
+				var rootDestPath = Path.Combine(outputDir, spec.FileName);
+				FileSystem.CopyFile(spec.FilePath, rootDestPath, overwrite: true);
+			}
+		}
+
+		private async Task<NuGetPackResult> GenerateAndPackContractAsync(
+			string outputDir,
+			Dictionary<string, List<string>> specsByKind,
+			string description)
+		{
+			var generator = new ContractPackageGenerator(TemplateRenderer, FileSystem);
+			var options = new ContractPackageOptions
+			{
+				PackageId = PackageId,
+				Version = Version,
+				Authors = Authors,
+				Description = description,
+				OutputDirectory = outputDir,
+				PackageProperties = StringHelpers.ParseKeyValuePairs(PackageProperties),
+				SpecsByKind = specsByKind
+			};
+
+			var generated = await generator.GenerateContractPackageAsync(options);
+			Console.WriteLine($"Generated: {generated.NuspecPath}");
+			Console.WriteLine($"Generated: {generated.TargetsPath}");
+
+			// Pack the nuspec
+			return await NuGetService.PackAsync(generated.NuspecPath, outputDir, outputDir);
+		}
+
+		private async Task<NuGetPackResult> GenerateAndPackClientAsync(
+			string outputDir,
+			Dictionary<string, List<string>> specsByKind,
+			string description)
+		{
+			var clientPackageId = ClientPackageId ?? $"{PackageId}.Client";
+			var hasOpenApi = specsByKind.ContainsKey(SpecKind.OpenApi);
+			var hasAsyncApi = specsByKind.ContainsKey(SpecKind.AsyncApi);
+
+			var clientClass = ClientClassName ?? $"{StringHelpers.SanitizeClassName(PackageId)}Client";
+			var normalizedNswagOptions = GetNormalizedNswagOptions(hasOpenApi);
+			var clientOptions = hasAsyncApi
+				? StringHelpers.ParseKeyValuePairs(ClientOptions)
+					.Select(kvp => new KeyValuePair<string, string>(StringHelpers.NormalizePrefix("ConcordIOClient", kvp.Key), kvp.Value))
+					.ToList()
+				: [];
+
+			var generator = new ContractPackageGenerator(TemplateRenderer, FileSystem);
+			var options = new ClientPackageOptions
+			{
+				ClientPackageId = clientPackageId,
+				ContractPackageId = PackageId,
+				ContractVersion = Version,
+				Version = Version,
+				Authors = Authors,
+				Description = $"Client generator for {PackageId}. Generates code from contract specifications.",
+				OutputDirectory = outputDir,
+				NSwagClientClassName = clientClass,
+				NSwagOutputPath = clientClass,
+				NSwagOptions = normalizedNswagOptions,
+				ClientOptions = clientOptions,
+				PackageProperties = StringHelpers.ParseKeyValuePairs(PackageProperties),
+				SpecsByKind = specsByKind
+			};
+
+			var generated = await generator.GenerateClientPackageAsync(options);
+			Console.WriteLine($"Generated: {generated.NuspecPath}");
+			Console.WriteLine($"Generated: {generated.TargetsPath}");
+
+			// Pack the nuspec
+			return await NuGetService.PackAsync(generated.NuspecPath, outputDir, outputDir);
+		}
+
+		private List<KeyValuePair<string, string>> GetNormalizedNswagOptions(bool hasOpenApi)
+		{
+			if (!hasOpenApi)
+			{
+				return [];
+			}
+
+			var parsedNswagOptions = StringHelpers.ParseKeyValuePairs(NswagOptions);
+			var normalizedNswagOptions = parsedNswagOptions
+				.Select(kvp => new KeyValuePair<string, string>(StringHelpers.NormalizePrefix("NSwag", kvp.Key), kvp.Value))
+				.ToList();
+
+			var stjOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+			{
+				{ "NSwagJsonLibrary", "SystemTextJson" },
+				{ "NSwagJsonPolymorphicSerializationStyle", "SystemTextJson" }
+			};
+
+			if (!normalizedNswagOptions.Any(o => stjOptions.ContainsKey(o.Key)))
+			{
+				normalizedNswagOptions.AddRange(stjOptions);
+			}
+
+			if (!normalizedNswagOptions.Any(o => string.Equals("NSwagGenerateExceptionClasses", o.Key, StringComparison.OrdinalIgnoreCase)))
+			{
+				normalizedNswagOptions.Add(new("NSwagGenerateExceptionClasses", "true"));
+			}
+
+			return normalizedNswagOptions;
+		}
+	}
+}

--- a/src/ConcordIO.Tool/CliCommands/PackCommand.cs
+++ b/src/ConcordIO.Tool/CliCommands/PackCommand.cs
@@ -352,7 +352,8 @@ public partial class RootCommand
 			var stjOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
 			{
 				{ "NSwagJsonLibrary", "SystemTextJson" },
-				{ "NSwagJsonPolymorphicSerializationStyle", "SystemTextJson" }
+				{ "NSwagJsonPolymorphicSerializationStyle", "SystemTextJson" },
+				{ "NSwagGenerateNullableReferenceTypes", "false" }
 			};
 
 			if (!normalizedNswagOptions.Any(o => stjOptions.ContainsKey(o.Key)))

--- a/src/ConcordIO.Tool/README.md
+++ b/src/ConcordIO.Tool/README.md
@@ -89,7 +89,7 @@ concordio generate \
 The `generate` command produces two NuGet package scaffolds:
 
 1. **Contract package** (`{PackageId}`) — contains the specification files and a `.targets` file that exposes them as `ConcordIOContract` MSBuild items to consuming projects.
-2. **Client package** (`{PackageId}.Client`) — contains a `.targets` file that wires contract specs to code generators (NSwag for OpenAPI, ConcordIO.AsyncApi.Client for AsyncAPI) at build time.
+2. **Client package** (`{PackageId}.Client`) — contains a `.targets` file that wires contract specs to code generators (NSwag for OpenAPI, ConcordIO.AsyncApi.Client for AsyncAPI) at build time. For AsyncAPI, the generated client package depends on `ConcordIO.AsyncApi.Client` with a minimum version equal to the current `ConcordIO.Tool` version (NuGet range `[toolVersion,)`).
 
 ---
 

--- a/src/ConcordIO.Tool/README.md
+++ b/src/ConcordIO.Tool/README.md
@@ -200,6 +200,88 @@ concordio get-spec \
   --kind asyncapi
 ```
 
+---
+
+### `concordio pack`
+
+Generate and pack contract NuGet packages (.nupkg) from specification files. Combines `generate` functionality with `nuget pack` to produce ready-to-publish packages.
+
+```bash
+concordio pack \
+  --spec <path[:kind]> \
+  --package-id <id> \
+  --version <semver>
+```
+
+**Required options:**
+
+| Option | Description |
+|--------|-------------|
+| `--spec` | Specification file(s) with optional kind suffix (format: `path[:kind]`). Kind defaults to `openapi`. Valid kinds: `openapi`, `proto`, `asyncapi`. Can be specified multiple times. |
+| `--package-id` | Package ID for the generated NuGet package. |
+| `--version` | SemVer version for the package. |
+
+**Optional options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--authors` | `ConcordIO` | Package authors. |
+| `--description` | Auto-generated | Package description. |
+| `--output` | `.` | Output directory for generated files and .nupkg packages. |
+| `--client` | `true` | Also generate and pack a client package. |
+| `--client-package-id` | `{PackageId}.Client` | Client package ID. |
+| `--client-class-name` | Derived from PackageId | Client class name (OpenAPI only). |
+| `--nswag-options` | — | Additional NSwag options as `key=value` (OpenAPI only, repeatable). |
+| `--client-options` | — | Additional client options as `key=value` (AsyncAPI only, repeatable). |
+| `--package-properties` | — | Additional NuSpec metadata as `key=value` (repeatable). |
+
+**Examples:**
+
+```bash
+# Pack a single OpenAPI spec
+concordio pack \
+  --spec petstore.yaml \
+  --package-id Contoso.PetStore.Api \
+  --version 1.0.0
+
+# Pack with client package to a specific output directory
+concordio pack \
+  --spec api.yaml \
+  --package-id Contoso.Api \
+  --version 2.0.0 \
+  --output ./packages
+
+# Pack multiple specs of different kinds
+concordio pack \
+  --spec api.yaml:openapi \
+  --spec events.yaml:asyncapi \
+  --package-id Contoso.Service \
+  --version 1.0.0
+
+# Pack contract only (no client)
+concordio pack \
+  --spec service.proto:proto \
+  --package-id Contoso.Grpc.Api \
+  --version 1.0.0 \
+  --client false
+```
+
+**Output:**
+
+The `pack` command produces `.nupkg` files:
+
+1. **Contract package** (`{PackageId}.{Version}.nupkg`) — ready-to-publish NuGet package containing spec files and MSBuild targets.
+2. **Client package** (`{PackageId}.Client.{Version}.nupkg`) — if `--client` is enabled, a development dependency package for code generation.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|--------|
+| `0` | Packages created successfully. |
+| `1` | Error (e.g., invalid arguments, missing spec files, nuget pack failure). |
+
+---
+
 ## How It Works
 
 ### Contract Packages

--- a/src/ConcordIO.Tool/README.md
+++ b/src/ConcordIO.Tool/README.md
@@ -52,6 +52,51 @@ concordio generate \
 | `--client-options` | — | Additional client options as `key=value` (AsyncAPI only, repeatable). Values may contain '=' characters. |
 | `--package-properties` | — | Additional NuSpec metadata as `key=value` (repeatable). Values may contain '=' characters. |
 
+For OpenAPI client generation, ConcordIO applies these NSwag defaults unless you override them via `--nswag-options`:
+
+- `NSwagJsonLibrary=SystemTextJson`
+- `NSwagJsonPolymorphicSerializationStyle=SystemTextJson`
+- `NSwagGenerateNullableReferenceTypes=false`
+- `NSwagGenerateExceptionClasses=true`
+
+### Customizing Generated Clients
+
+Client packages generated from OpenAPI contracts wire specs to NSwag at build time. You can customize the generated client by overriding `OpenApiReference` metadata in your consuming project.
+
+#### Standard Metadata (No Prefix)
+
+These properties control MSBuild orchestration and don't require the `NSwag` prefix:
+
+- **`Namespace`** — Generated code namespace
+- **`ClassName`** — Generated client class name
+- **`OutputPath`** — Location of generated file
+- **`CodeGenerator`** — Code generator to use (e.g., `NSwagCSharp`)
+
+#### NSwag Generator Options (Prefix Required)
+
+NSwag-specific code generation settings must be prefixed with `NSwag`:
+
+- **`NSwagJsonLibrary`** — JSON serializer (`SystemTextJson` or `NewtonsoftJson`)
+- **`NSwagGenerateNullableReferenceTypes`** — Enable nullable reference types (`true` or `false`)
+- **`NSwagGenerateExceptionClasses`** — Generate typed exception classes (`true` or `false`)
+- **`NSwagInjectHttpClient`** — Use dependency injection for HttpClient (`true` or `false`)
+- **`NSwagGenerateClientInterfaces`** — Generate client interfaces (`true` or `false`)
+
+#### Example: Override Namespace and Disable Nullable Reference Types
+
+```xml
+<Target Name="CustomizeOpenApiReference" AfterTargets="ConcordIOAddOpenApiReferenceForNSwag">
+  <ItemGroup>
+    <OpenApiReference Update="@(OpenApiReference)">
+      <Namespace>MyApp.Generated.Clients</Namespace>
+      <NSwagGenerateNullableReferenceTypes>false</NSwagGenerateNullableReferenceTypes>
+    </OpenApiReference>
+  </ItemGroup>
+</Target>
+```
+
+**Why the difference?** The unprefixed properties (`Namespace`, `ClassName`, etc.) are defined by `Microsoft.Extensions.ApiDescription.Client` — the MSBuild infrastructure that NSwag builds upon. The `NSwag`-prefixed properties are passed directly to NSwag's code generator.
+
 **Examples:**
 
 ```bash
@@ -88,7 +133,7 @@ concordio generate \
 
 The `generate` command produces two NuGet package scaffolds:
 
-1. **Contract package** (`{PackageId}`) — contains the specification files and a `.targets` file that exposes them as `ConcordIOContract` MSBuild items to consuming projects.
+1. **Contract package** (`{PackageId}`) — contains the specification files and `.targets` files in both `build/` and `buildTransitive/` so `ConcordIOContract` items flow to direct and transitive consumers (for example, when only a client package is referenced).
 2. **Client package** (`{PackageId}.Client`) — contains a `.targets` file that wires contract specs to code generators (NSwag for OpenAPI, ConcordIO.AsyncApi.Client for AsyncAPI) at build time. For AsyncAPI, the generated client package depends on `ConcordIO.AsyncApi.Client` with a minimum version equal to the current `ConcordIO.Tool` version (NuGet range `[toolVersion,)`).
 
 ---
@@ -235,6 +280,13 @@ concordio pack \
 | `--client-options` | — | Additional client options as `key=value` (AsyncAPI only, repeatable). |
 | `--package-properties` | — | Additional NuSpec metadata as `key=value` (repeatable). |
 
+For OpenAPI client generation, ConcordIO applies these NSwag defaults unless you override them via `--nswag-options`:
+
+- `NSwagJsonLibrary=SystemTextJson`
+- `NSwagJsonPolymorphicSerializationStyle=SystemTextJson`
+- `NSwagGenerateNullableReferenceTypes=false`
+- `NSwagGenerateExceptionClasses=true`
+
 **Examples:**
 
 ```bash
@@ -287,6 +339,7 @@ The `pack` command produces `.nupkg` files:
 ### Contract Packages
 
 The `generate` command creates a NuGet package that:
+
 - Bundles the specification files as content.
 - Includes a `.targets` file that exposes specs as `ConcordIOContract` (OpenAPI/Proto) or `ConcordIOAsyncApiContract` (AsyncAPI) MSBuild items.
 - Consuming projects automatically see the contract files after installing the package — no file copying needed.
@@ -294,19 +347,33 @@ The `generate` command creates a NuGet package that:
 ### Client Packages
 
 The client package is a **development dependency** that:
+
 - Declares a dependency on the corresponding contract package.
 - Wires the contract specs to code generators at build time:
   - **OpenAPI** → [NSwag](https://github.com/RicoSuter/NSwag) (generates C# client classes)
   - **AsyncAPI** → ConcordIO.AsyncApi.Client (generates messaging client code)
+- For **AsyncAPI**, updates `ConcordIOAsyncApiContract` item metadata in-place (MSBuild `Update`) so consuming builds do not duplicate the same contract path.
 - Consuming projects just install the client package and get strongly-typed clients generated automatically on build.
 
 ### Breaking-Change Detection
 
 The `breaking` command:
+
 1. Downloads the published contract NuGet package.
 2. Extracts the specification file.
 3. Runs [oasdiff](https://github.com/Tufin/oasdiff) to compare the local spec against the published one.
 4. Reports breaking changes with a non-zero exit code, suitable for CI/CD gates.
+
+## Known Limitation: OpenAPI Client Generation in Multi-TFM Consumers
+
+OpenAPI client generation currently relies on the NSwag + `Microsoft.Extensions.ApiDescription.Client` MSBuild orchestration path. In some projects that use `<TargetFrameworks>` (multi-targeting), NSwag can skip generation due to target-ordering behavior in the outer/inner build dispatch.
+
+- **Affected scenario**: Consumer projects using multi-targeting with generated OpenAPI client packages.
+- **Observed failure**: Missing generated client types at compile time (for example `CS0246`).
+- **Current recommendation**: Prefer single-target projects (`<TargetFramework>`) when consuming generated OpenAPI client packages.
+- **Tracking issue**: [#61](https://github.com/LevDevIO/ConcordIO/issues/61).
+
+For automated validation, the E2E suite now uses single-TFM projects with separate coverage for net8.0, net9.0, and net10.0.
 
 ## Prerequisites
 
@@ -316,6 +383,7 @@ The `breaking` command:
 ## Supported Platforms
 
 The tool bundles oasdiff binaries for:
+
 - Windows x64 / ARM64
 - Linux x64 / ARM64
 - macOS (universal)

--- a/src/ConcordIO.Tool/Services/ContractPackageGenerator.cs
+++ b/src/ConcordIO.Tool/Services/ContractPackageGenerator.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace ConcordIO.Tool.Services;
 
 /// <summary>
@@ -112,6 +114,7 @@ public class ContractPackageGenerator
 			["description"] = options.Description,
 			["contract_package_id"] = options.ContractPackageId,
 			["contract_version"] = options.ContractVersion,
+			["tool_version"] = GetToolVersionOrThrow(),
 			["package_properties"] = options.PackageProperties,
 			["nswag_client_class_name"] = options.NSwagClientClassName,
 			["nswag_output_path"] = options.NSwagOutputPath,
@@ -121,6 +124,21 @@ public class ContractPackageGenerator
 			["has_proto"] = hasProto,
 			["has_asyncapi"] = hasAsyncApi
 		};
+	}
+
+	private static string GetToolVersionOrThrow()
+	{
+		var informationalVersion = typeof(ContractPackageGenerator).Assembly
+			.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()
+			?.InformationalVersion;
+		var normalizedVersion = informationalVersion?.Split('+')[0];
+		if (string.IsNullOrWhiteSpace(normalizedVersion))
+		{
+			throw new InvalidOperationException(
+				"ConcordIO tool version metadata is missing. Ensure <Version> is set and assembly informational version is generated.");
+		}
+
+		return normalizedVersion;
 	}
 }
 

--- a/src/ConcordIO.Tool/Services/ContractPackageGenerator.cs
+++ b/src/ConcordIO.Tool/Services/ContractPackageGenerator.cs
@@ -25,12 +25,19 @@ public class ContractPackageGenerator
 
 		var model = BuildContractModel(options);
 
-		return await GeneratePackageAsync(
+		var generatedPackage = await GeneratePackageAsync(
 			options.PackageId,
 			options.OutputDirectory,
 			"Contract.Contract.nuspec",
 			"Contract.Contracts.targets",
 			model);
+
+		var buildTransitiveDir = Path.Combine(options.OutputDirectory, "buildTransitive");
+		_fileSystem.CreateDirectory(buildTransitiveDir);
+		var buildTransitiveTargetsPath = Path.Combine(buildTransitiveDir, $"{options.PackageId}.targets");
+		await _fileSystem.WriteAllTextAsync(buildTransitiveTargetsPath, generatedPackage.TargetsContent);
+
+		return generatedPackage;
 	}
 
 	/// <summary>

--- a/src/ConcordIO.Tool/Services/FileSystem.cs
+++ b/src/ConcordIO.Tool/Services/FileSystem.cs
@@ -18,4 +18,7 @@ public class FileSystem : IFileSystem
 	public string[] GetFiles(string path, string searchPattern = "*") => Directory.GetFiles(path, searchPattern);
 
 	public string[] GetDirectories(string path) => Directory.GetDirectories(path);
+
+	public void CopyFile(string sourceFileName, string destFileName, bool overwrite = false) =>
+		File.Copy(sourceFileName, destFileName, overwrite);
 }

--- a/src/ConcordIO.Tool/Services/IFileSystem.cs
+++ b/src/ConcordIO.Tool/Services/IFileSystem.cs
@@ -90,4 +90,12 @@ public interface IFileSystem
 	/// <param name="path">The path to the directory to search.</param>
 	/// <returns>An array of directory paths.</returns>
 	string[] GetDirectories(string path);
+
+	/// <summary>
+	/// Copies a file to a new location, optionally overwriting the destination.
+	/// </summary>
+	/// <param name="sourceFileName">The file to copy.</param>
+	/// <param name="destFileName">The destination path for the copied file.</param>
+	/// <param name="overwrite">If <c>true</c>, overwrites the destination file if it exists; otherwise, throws if the destination exists.</param>
+	void CopyFile(string sourceFileName, string destFileName, bool overwrite = false);
 }

--- a/src/ConcordIO.Tool/Services/INuGetService.cs
+++ b/src/ConcordIO.Tool/Services/INuGetService.cs
@@ -80,4 +80,70 @@ public interface INuGetService
 	/// </code>
 	/// </example>
 	Task<int> DownloadPackageAsync(string outputDir, string packageId, string? version, bool prerelease);
+
+	/// <summary>
+	/// Creates a NuGet package (.nupkg) from a .nuspec file.
+	/// </summary>
+	/// <param name="nuspecPath">The path to the .nuspec file to pack.</param>
+	/// <param name="outputDir">The directory where the .nupkg file will be created.</param>
+	/// <param name="basePath">The base path for resolving relative file references in the .nuspec.
+	/// Typically the directory containing the spec files.</param>
+	/// <returns>
+	/// A <see cref="NuGetPackResult"/> containing the exit code and output from the pack command:
+	/// <list type="bullet">
+	/// <item><description>Exit code <c>0</c> - Success</description></item>
+	/// <item><description>Non-zero exit code - Failure (missing files, invalid nuspec, etc.)</description></item>
+	/// </list>
+	/// </returns>
+	/// <remarks>
+	/// <para>
+	/// The package is created using <c>nuget pack</c> which:
+	/// </para>
+	/// <list type="bullet">
+	/// <item><description>Validates the .nuspec file structure</description></item>
+	/// <item><description>Resolves all file references relative to the base path</description></item>
+	/// <item><description>Creates a .nupkg file named <c>{PackageId}.{Version}.nupkg</c></description></item>
+	/// </list>
+	/// </remarks>
+	/// <example>
+	/// <code>
+	/// var result = await nugetService.PackAsync(
+	///     nuspecPath: "output/MyPackage.nuspec",
+	///     outputDir: "output/packages",
+	///     basePath: "output"
+	/// );
+	/// 
+	/// if (result.ExitCode == 0)
+	/// {
+	///     Console.WriteLine($"Package created: {result.NupkgPath}");
+	/// }
+	/// </code>
+	/// </example>
+	Task<NuGetPackResult> PackAsync(string nuspecPath, string outputDir, string basePath);
+}
+
+/// <summary>
+/// Result of a NuGet pack operation.
+/// </summary>
+public class NuGetPackResult
+{
+	/// <summary>
+	/// Gets the exit code from the nuget pack command.
+	/// </summary>
+	public required int ExitCode { get; init; }
+
+	/// <summary>
+	/// Gets the combined standard output and error from the pack command.
+	/// </summary>
+	public required string Output { get; init; }
+
+	/// <summary>
+	/// Gets the path to the created .nupkg file, if the pack was successful.
+	/// </summary>
+	public string? NupkgPath { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether the pack operation was successful.
+	/// </summary>
+	public bool Success => ExitCode == 0;
 }

--- a/src/ConcordIO.Tool/Services/NuGetService.cs
+++ b/src/ConcordIO.Tool/Services/NuGetService.cs
@@ -1,11 +1,12 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace ConcordIO.Tool.Services;
 
 /// <summary>
 /// Default implementation of <see cref="INuGetService"/> that uses the nuget CLI.
 /// </summary>
-public class NuGetService : INuGetService
+public partial class NuGetService : INuGetService
 {
 	public async Task<int> DownloadPackageAsync(string outputDir, string packageId, string? version, bool prerelease)
 	{
@@ -39,4 +40,54 @@ public class NuGetService : INuGetService
 
 		return process.ExitCode;
 	}
+
+	/// <inheritdoc />
+	public async Task<NuGetPackResult> PackAsync(string nuspecPath, string outputDir, string basePath)
+	{
+		var arguments = $"pack \"{nuspecPath}\" -OutputDirectory \"{outputDir}\" -BasePath \"{basePath}\"";
+
+		using var process = new Process();
+		process.StartInfo = new ProcessStartInfo
+		{
+			FileName = "nuget",
+			Arguments = arguments,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+			CreateNoWindow = true
+		};
+
+		process.Start();
+
+		var outputTask = process.StandardOutput.ReadToEndAsync();
+		var errorTask = process.StandardError.ReadToEndAsync();
+
+		await process.WaitForExitAsync();
+
+		var output = await outputTask;
+		var error = await errorTask;
+		var combinedOutput = output + error;
+
+		// Parse the output to find the created .nupkg path
+		// NuGet outputs something like: "Successfully created package 'C:\path\to\Package.1.0.0.nupkg'."
+		string? nupkgPath = null;
+		if (process.ExitCode == 0)
+		{
+			var match = NupkgPathRegex().Match(combinedOutput);
+			if (match.Success)
+			{
+				nupkgPath = match.Groups[1].Value;
+			}
+		}
+
+		return new NuGetPackResult
+		{
+			ExitCode = process.ExitCode,
+			Output = combinedOutput,
+			NupkgPath = nupkgPath
+		};
+	}
+
+	[GeneratedRegex(@"Successfully created package '([^']+\.nupkg)'", RegexOptions.IgnoreCase)]
+	private static partial Regex NupkgPathRegex();
 }

--- a/src/ConcordIO.Tool/Templates/Contract.Client/Contract.Client.nuspec
+++ b/src/ConcordIO.Tool/Templates/Contract.Client/Contract.Client.nuspec
@@ -9,6 +9,7 @@
   - client_package_id:    The client package ID (e.g., "MyService.Contracts.Client")
   - contract_package_id:  The referenced contract package ID
   - contract_version:     The contract package version to depend on
+  - tool_version:         The ConcordIO.Tool version used to generate the package
   - version:              The client package version
   - authors:              Package author(s)
   - description:          Package description
@@ -26,7 +27,7 @@
   - NSwag.ApiDescription.Client: For OpenAPI → C# HTTP clients
 {{~ end ~}}
 {{~ if has_asyncapi ~}}
-  - ConcordIO.AsyncApi.Client:   For AsyncAPI → C# message contracts
+  - ConcordIO.AsyncApi.Client:   For AsyncAPI → C# message contracts (min = tool version)
 {{~ end ~}}
   
   Dependencies use exclude="compile,runtime" to prevent shipping generator assemblies.
@@ -51,7 +52,7 @@
 {{~ end ~}}
 {{~ if has_asyncapi ~}}
             <!-- ConcordIO generates message contracts from AsyncAPI specs -->
-            <dependency id="ConcordIO.AsyncApi.Client" version="0.1.*" include="build" exclude="compile,runtime"/>
+            <dependency id="ConcordIO.AsyncApi.Client" version="[{{ tool_version }},)" include="build" exclude="compile,runtime"/>
 {{~ end ~}}
         </dependencies>
     </metadata>

--- a/src/ConcordIO.Tool/Templates/Contract.Client/Contract.Client.targets
+++ b/src/ConcordIO.Tool/Templates/Contract.Client/Contract.Client.targets
@@ -17,8 +17,8 @@
   
   TARGET EXECUTION ORDER:
   1. Package restore creates ConcordIOContract/ConcordIOAsyncApiContract items
-  2. AfterTargets="ResolvePackageAssets" - these targets run
-  3. Items are enriched with code generation metadata
+  2. BeforeTargets="GenerateOpenApiCode" - OpenAPI references are materialized for NSwag
+  3. AfterTargets="ResolvePackageAssets" - AsyncAPI metadata enrichment runs
   4. Code generators (NSwag, ConcordIO.AsyncApi.Client) consume the items
   
   TROUBLESHOOTING:
@@ -36,18 +36,19 @@
       
       OUTPUT: {nswag_output_path}.cs containing typed HTTP client
     -->
-    <Target Name="ConcordIOAddOpenApiReferenceForNSwag" 
-            AfterTargets="ResolvePackageAssets"
+        <Target Name="ConcordIOAddOpenApiReferenceForNSwag"
+          BeforeTargets="GenerateOpenApiCode"
             Condition="'@(ConcordIOContract)' != ''">
         <ItemGroup>
             <!-- Filter to specs from this contract package with openapi kind -->
-            <OpenApiReference Include="@(ConcordIOContract)" 
+            <OpenApiReference Include="@(ConcordIOContract)"
                               Condition="'%(ConcordIOContract.PackageId)' == '{{ contract_package_id }}' And '%(ConcordIOContract.Kind)' == 'openapi'">
+                <!-- Standard MSBuild metadata (no prefix needed) -->
                 <CodeGenerator>NSwagCSharp</CodeGenerator>
                 <ClassName>{{ nswag_client_class_name }}</ClassName>
                 <OutputPath>{{ nswag_output_path }}.cs</OutputPath>
 {{~ for option in nswag_options ~}}
-                <!-- Custom NSwag option: {{ option.key }} -->
+                <!-- NSwag generator option: {{ option.key }} (prefix required for NSwag-specific settings) -->
                 <{{ option.key }}>{{ option.value }}</{{ option.key }}>
 {{~ end ~}}
             </OpenApiReference>
@@ -63,12 +64,12 @@
       
       OUTPUT: {Namespace}.g.cs files with message contract classes
     -->
-    <Target Name="ConcordIOAddAsyncApiContractForGeneration" 
+    <Target Name="ConcordIOAddAsyncApiContractForGeneration"
             AfterTargets="ResolvePackageAssets"
             Condition="'@(ConcordIOAsyncApiContract)' != ''">
         <ItemGroup>
-            <!-- Filter to specs from this contract package -->
-            <ConcordIOAsyncApiContract Include="@(ConcordIOAsyncApiContract)" 
+        <!-- Filter to specs from this contract package and update metadata in-place (no duplicate items). -->
+        <ConcordIOAsyncApiContract Update="@(ConcordIOAsyncApiContract)"
                                        Condition="'%(ConcordIOAsyncApiContract.PackageId)' == '{{ contract_package_id }}'">
                 <SourcePackage>{{ contract_package_id }}</SourcePackage>
                 <SourceVersion>{{ contract_version }}</SourceVersion>

--- a/src/ConcordIO.Tool/Templates/Contract/Contract.nuspec
+++ b/src/ConcordIO.Tool/Templates/Contract/Contract.nuspec
@@ -18,7 +18,8 @@
   GENERATED STRUCTURE:
   - contentFiles/any/any/{spec}  - IDE visibility (allows viewing in Solution Explorer)
   - {kind}/{spec}                - Organized by spec type for MSBuild targets
-  - build/{package_id}.targets   - MSBuild integration exposing specs as items
+  - build/{package_id}.targets   - MSBuild integration exposing specs as items (direct reference)
+  - buildTransitive/{package_id}.targets - MSBuild integration for transitive references
   
   EXAMPLE OUTPUT:
   A package with openapi/petstore.yaml and asyncapi/events.yaml creates:
@@ -55,5 +56,6 @@
 {{~ end ~}}
     <!-- MSBuild targets file exposes specs as ConcordIOContract/ConcordIOAsyncApiContract items -->
     <file src="build/{{ package_id }}.targets" target="build/{{ package_id }}.targets" />
+    <file src="buildTransitive/{{ package_id }}.targets" target="buildTransitive/{{ package_id }}.targets" />
   </files>
 </package>


### PR DESCRIPTION
- Add PackCommand that combines generate + nuget pack functionality
- Extend INuGetService with PackAsync method and NuGetPackResult class
- Add CopyFile method to IFileSystem for spec file copying
- Copy spec files to both kind folders and root for proper packaging
- Add unit tests for NuGetPackResult (8 tests)
- Add E2E tests for PackCommand (7 tests)
- Update README.md with pack command documentation
- Update ARCHITECTURE.md with PackCommand design details
